### PR TITLE
Adding support for usage with standalone WireMock

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the `GET` won't have any knowledge of the previous post.
 
 | `wiremock-extension-state` version | `WireMock` version |
 |------------------------------------|--------------------|
-| `0.0.3`                            | `3.0.0-beta-11`+   |
+| `0.0.3`+                           | `3.0.0-beta-11`+   |
 
 ## Installation
 
@@ -100,8 +100,11 @@ add authentication to GitHub packages.
 
 ## Register extension
 
+### Java
+
 This extension makes use of Wiremock's `ExtensionFactory`, so only one extension has to be registered: `StateExtension`.
-In order to use them, templating has to be enabled as well:
+In order to use them, templating has to be enabled as well. A store for all state data has to be provided. This extension
+provides a `CaffeineStore` which can be used - or you can provide your own store:
 
 ```java
 public class MySandbox {
@@ -120,6 +123,17 @@ public class MySandbox {
         server.start();
     }
 }
+```
+
+### Standalone
+
+This extension uses the `ServiceLoader` extension to be loaded by WireMock. As Standalone version, it will use `CaffeineStore` for
+storing any data.
+
+The standalone jar can be downloaded from [GitHub](https://github.com/wiremock/wiremock-extension-state/packages/1902576) .
+
+```bash
+java -cp "wiremock-state-extension-standalone-0.0.4.jar:wiremock-standalone-3.0.0-beta-11.jar" wiremock.Run
 ```
 
 ## Record a state
@@ -349,8 +363,6 @@ As for other matchers, templating is supported.
   }
 }
 ```
-
-
 
 ## Retrieve a state
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,16 @@ plugins {
     id 'jacoco'
     id 'com.diffplug.spotless' version '6.20.0'
     id 'com.palantir.git-version' version '3.0.0'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 wrapper {
-    gradleVersion = '7.2'
+    gradleVersion = '8.2.1'
     distributionType = Wrapper.DistributionType.BIN
 }
-project.archivesBaseName = 'wiremock-state-extension'
+
 project.ext {
+    baseArtifact = 'wiremock-state-extension'
     versions = [
             wiremock  : '3.0.0-beta-12',
             caffeine  : '3.1.6',
@@ -32,6 +34,42 @@ project.ext {
     ]
 }
 
+project.archivesBaseName = "${baseArtifact}"
+configurations {
+    standaloneOnly
+}
+
+jar {
+    archiveBaseName.set("${baseArtifact}")
+    exclude 'META-INF/services'
+}
+
+shadowJar {
+    archiveBaseName.set("${baseArtifact}-standalone")
+    archiveClassifier.set('')
+    configurations = [
+            project.configurations.runtimeClasspath,
+            project.configurations.standaloneOnly
+    ]
+
+    with copySpec {
+        from("shadowjar/resources") {}
+    }
+
+    relocate "com.github.ben-manes.caffeine", 'wiremock.org.extensions.state.caffeine'
+    relocate "com.github.jknack", 'wiremock.org.extensions.state.jknack'
+
+
+    dependencies {
+        exclude(dependency('junit:junit'))
+    }
+
+    mergeServiceFiles()
+
+    exclude 'META-INF/maven/**'
+    exclude 'module-info.class'
+    exclude 'handlebars-*.js'
+}
 
 group 'org.wiremock'
 
@@ -48,15 +86,57 @@ publishing {
             }
         }
     }
+
+    getComponents().withType(AdhocComponentWithVariants).each { c ->
+        c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
+            skip()
+        }
+    }
+
     publications {
         mavenJava(MavenPublication) {
-            artifactId = 'wiremock-state-extension'
+            artifactId = "${baseArtifact}"
 
             from components.java
 
             pom {
-                name = 'wiremock-state-extension'
+                name = "${baseArtifact}"
                 description = 'A WireMock extension to transfer state in between stubs'
+                url = 'https://github.com/dirkbolte/wiremock-extension-state'
+
+
+                scm {
+                    connection = 'https://github.com/dirkbolte/wiremock-extension-state.git'
+                    developerConnection = 'https://github.com/dirkbolte/wiremock-extension-state.git'
+                    url = 'https://github.com/dirkbolte/wiremock-extension-state.git'
+                }
+
+                licenses {
+                    license {
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'dirkbolte'
+                        name = 'Dirk Bolte'
+                        email = 'dirk.bolte@gmx.de'
+                    }
+                }
+            }
+        }
+        standaloneJar(MavenPublication) { publication ->
+            artifactId = "${baseArtifact}-standalone"
+
+            project.shadow.component(publication)
+
+            pom {
+
+                name = "${baseArtifact}-standalone"
+                description = 'A WireMock extension to transfer state in between stubs - to be used with WireMock standalone'
                 url = 'https://github.com/dirkbolte/wiremock-extension-state'
 
 
@@ -117,6 +197,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+assemble.dependsOn jar, shadowJar
 
 test {
     useJUnitPlatform()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/shadowjar/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.ExtensionFactory
+++ b/shadowjar/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.ExtensionFactory
@@ -1,0 +1,1 @@
+org.wiremock.extensions.state.StandaloneStateExtension

--- a/src/main/java/org/wiremock/extensions/state/StandaloneStateExtension.java
+++ b/src/main/java/org/wiremock/extensions/state/StandaloneStateExtension.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Dirk Bolte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.extensions.state;
+
+import com.github.tomakehurst.wiremock.extension.Extension;
+import com.github.tomakehurst.wiremock.extension.ExtensionFactory;
+import com.github.tomakehurst.wiremock.extension.WireMockServices;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
+import com.github.tomakehurst.wiremock.store.Store;
+import org.wiremock.extensions.state.extensions.DeleteStateEventListener;
+import org.wiremock.extensions.state.extensions.RecordStateEventListener;
+import org.wiremock.extensions.state.extensions.StateRequestMatcher;
+import org.wiremock.extensions.state.extensions.StateTemplateHelperProviderExtension;
+import org.wiremock.extensions.state.internal.ContextManager;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Factory to register all extensions for handling state for standalone service.
+ *
+ * Uses {@link org.wiremock.extensions.state.CaffeineStore}.
+ *
+ * @see CaffeineStore
+ */
+public class StandaloneStateExtension implements ExtensionFactory {
+
+    private final TemplateEngine templateEngine = new TemplateEngine(Collections.emptyMap(), null, Collections.emptySet(), false);
+
+    private final Store<String, Object> store = new CaffeineStore();
+
+    private final ContextManager contextManager = new ContextManager(store);;
+
+    @Override
+    public List<Extension> create(WireMockServices services) {
+        return List.of(
+            new RecordStateEventListener(contextManager, templateEngine),
+            new DeleteStateEventListener(contextManager, templateEngine),
+            new StateRequestMatcher(contextManager, templateEngine),
+            new StateTemplateHelperProviderExtension(contextManager)
+        );
+    }
+}


### PR DESCRIPTION
- providing ServiceLoader for extension factory (using CaffeineStore)
- adding publication for standalone jar with shadowJar
- extending documentation

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
