### PR TITLE
`state` template helper `default` property feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ The handler has the following parameters:
     - getting the first state in the list: `list='[0].myProperty`
     - getting the last state in the list: `list='[-1].myProperty`
     - getting an element based on a path segment:: `list=(join '[' request.pathSegments.[1] '].myProperty' '')`
+- `default` (Optional): value to return in case the context or property wasn't found. Without a default value, an error message would be returned instead.
 
 You have to choose either `property` or `list` (otherwise, you will get a configuration error).
 
@@ -673,6 +674,8 @@ Example response with error:
   "lastName": "Doe"
 }
 ```
+
+To avoid errors, you can specify a `default` for the state helper: `"clientId": "{{state context=request.pathSegments.[1] property='firstname' default='John'}}",`
 
 # Debugging
 


### PR DESCRIPTION
- adding default for state helper
- extend documentation

## References

#18 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
