### PR TITLE
stabilize `deleteRecord` tests

### DIFF
--- a/src/test/java/org/wiremock/extensions/state/AbstractTestBase.java
+++ b/src/test/java/org/wiremock/extensions/state/AbstractTestBase.java
@@ -12,7 +12,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.wiremock.extensions.state.internal.ContextManager;
 
+import java.time.Duration;
+
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -40,4 +44,11 @@ public class AbstractTestBase {
     void setupBase() {
         wm.resetAll();
     }
+
+    protected void assertContextNumUpdates(String context, int expected) {
+        await()
+            .pollInterval(Duration.ofMillis(10))
+            .atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(contextManager.numUpdates(context)).isEqualTo(expected));
+    }
+
 }

--- a/src/test/java/org/wiremock/extensions/state/DeleteStateEventListenerTest.java
+++ b/src/test/java/org/wiremock/extensions/state/DeleteStateEventListenerTest.java
@@ -340,8 +340,11 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
+            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
+            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
+            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteIndex/1", contextName);
@@ -360,8 +363,11 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
+            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
+            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
+            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteIndex/2", contextName);
@@ -380,8 +386,11 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
+            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
+            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
+            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteWhere/two", contextName);
@@ -400,8 +409,11 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
+            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
+            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
+            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteWhere/three", contextName);

--- a/src/test/java/org/wiremock/extensions/state/RecordStateEventListenerTest.java
+++ b/src/test/java/org/wiremock/extensions/state/RecordStateEventListenerTest.java
@@ -251,9 +251,7 @@ class RecordStateEventListenerTest extends AbstractTestBase {
 
             postRequest("state", context, "one");
 
-            await()
-                .pollInterval(Duration.ofMillis(10))
-                .atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(contextManager.numUpdates(context)).isEqualTo(1));
+            assertContextNumUpdates(context, 1);
         }
 
         @Test
@@ -264,9 +262,7 @@ class RecordStateEventListenerTest extends AbstractTestBase {
             postRequest("state", context, "one");
             postRequest("state", context, "one");
 
-            await()
-                .pollInterval(Duration.ofMillis(10))
-                .atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(contextManager.numUpdates(context)).isEqualTo(3));
+            assertContextNumUpdates(context, 3);
         }
 
         @Test
@@ -278,12 +274,8 @@ class RecordStateEventListenerTest extends AbstractTestBase {
             postRequest("state", contextTwo, "one");
             postRequest("state", contextOne, "one");
 
-            await()
-                .pollInterval(Duration.ofMillis(10))
-                .atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(contextManager.numUpdates(contextOne)).isEqualTo(2));
-            await()
-                .pollInterval(Duration.ofMillis(10))
-                .atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(contextManager.numUpdates(contextTwo)).isEqualTo(1));
+            assertContextNumUpdates(contextOne, 2);
+            assertContextNumUpdates(contextTwo, 1);
         }
 
     }


### PR DESCRIPTION
- adding assertions to tests to ensure insertion order

<!-- Please describe your pull request here. -->

## References

none.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
