### PR TITLE
Convert class diagram from PlantUML to mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,25 +24,19 @@ Adds support to transport state across different stubs.
 | `property` | A property of a `state`. A state can have multiple properties.                                                                                  |
 | `list`     | Next to the singularic state, a context can have a list of `states`. The list of `states` can be modified but `states` within the `list` can't. |
 
-```plantuml
-@startuml Data model
-!pragma layout smetana
+```mermaid
+classDiagram
+    direction LR
+    Store "1" *-- "*" Context
+    Context "1" *-- "1" State
+    Context "1" *-- "1" List
+    List "1" *-- "*" State
+    State "1" *-- "*" Property
+    class Property {
+        +String key
+        +String value
+    }
 
-class Store
-class Context
-class State
-class Property {
-  + String key
-  + String value
-}
-class List
-
-Store "1" *-> "*" Context
-Context "1" *-> "1" State
-Context "1" *-> "1" List
-List "1" *-> "*" State
-State "1" *-> Property
-@enduml
 ```
 
 ## Background


### PR DESCRIPTION
Convert class diagram from PlantUML to mermaid
## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
