### PR TITLE
Use BeforeRequestSent event for all event listeners

### DIFF
--- a/src/main/java/org/wiremock/extensions/state/extensions/RecordStateEventListener.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/RecordStateEventListener.java
@@ -49,7 +49,7 @@ public class RecordStateEventListener implements ServeEventListener, StateExtens
         this.templateEngine = templateEngine;
     }
 
-    public void afterComplete(ServeEvent serveEvent, Parameters parameters) {
+    public void beforeResponseSent(ServeEvent serveEvent, Parameters parameters) {
         var model = Map.of(
             "request", RequestTemplateModel.from(serveEvent.getRequest()),
             "response", ResponseTemplateModel.from(serveEvent.getResponse())

--- a/src/test/java/org/wiremock/extensions/state/functionality/DeleteStateEventListenerTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/DeleteStateEventListenerTest.java
@@ -217,7 +217,6 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             getRequest("state", context);
 
             await()
-                .pollDelay(Duration.ofSeconds(1))
                 .pollInterval(Duration.ofMillis(10))
                 .atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(contextManager.getContext(context)).isEmpty());
         }
@@ -231,11 +230,9 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             getRequest("state", context);
 
             await()
-                .pollDelay(Duration.ofSeconds(1))
                 .pollInterval(Duration.ofMillis(10))
                 .atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(contextManager.getContext(context)).isEmpty());
             await()
-                .pollDelay(Duration.ofSeconds(1))
                 .pollInterval(Duration.ofMillis(10))
                 .atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(contextManager.getContext(otherContext)).isPresent());
         }
@@ -290,9 +287,13 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             getRequest("list/deleteFirst", context);
 
             await()
-                .pollDelay(Duration.ofSeconds(1))
                 .pollInterval(Duration.ofMillis(10))
-                .atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(contextManager.getContext(context)).isEmpty());
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() ->
+                    assertThat(contextManager.getContext(context))
+                        .isPresent()
+                        .hasValueSatisfying(it -> assertThat(it.getList()).isEmpty())
+                );
         }
 
         @Test
@@ -300,9 +301,7 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
-            assertList(contextName, list -> assertThat(list).hasSize(1));
             postRequest("list", contextName, "two");
-            assertList(contextName, list -> assertThat(list).hasSize(2));
 
             getRequest("list/deleteFirst", contextName);
 
@@ -320,9 +319,7 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
-            assertList(contextName, list -> assertThat(list).hasSize(1));
             postRequest("list", contextName, "two");
-            assertList(contextName, list -> assertThat(list).hasSize(2));
 
             getRequest("list/deleteLast", contextName);
 
@@ -340,11 +337,8 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
-            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
-            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
-            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteIndex/1", contextName);
@@ -363,11 +357,8 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
-            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
-            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
-            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteIndex/2", contextName);
@@ -386,11 +377,8 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
-            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
-            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
-            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteWhere/two", contextName);
@@ -409,11 +397,8 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
             var contextName = RandomStringUtils.randomAlphabetic(5);
 
             postRequest("list", contextName, "one");
-            assertContextNumUpdates(contextName, 1);
             postRequest("list", contextName, "two");
-            assertContextNumUpdates(contextName, 2);
             postRequest("list", contextName, "three");
-            assertContextNumUpdates(contextName, 3);
             assertList(contextName, list -> assertThat(list).hasSize(3));
 
             getRequest("list/deleteWhere/three", contextName);
@@ -429,7 +414,6 @@ class DeleteStateEventListenerTest extends AbstractTestBase {
 
         private void assertList(String contextName, Consumer<LinkedList<Map<String, String>>> consumer) {
             await()
-                .pollDelay(Duration.ofMillis(10))
                 .pollInterval(Duration.ofMillis(10))
                 .atMost(ofSeconds(5))
                 .untilAsserted(() ->


### PR DESCRIPTION
- use BeforeRequestSent for all event listeners
- removed waits + delays in various tests
- fixed bug for deletion on non-existant/empty context

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
