### PR TITLE
Fix package relocation for standalone jar

### DIFF
--- a/.run/WireMock Docker Test.run.xml
+++ b/.run/WireMock Docker Test.run.xml
@@ -1,0 +1,33 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="WireMock Docker Test" type="docker-deploy" factoryName="docker-image" server-name="Docker">
+    <deployment type="docker-image">
+      <settings>
+        <option name="imageTag" value="wiremock/wiremock:3x" />
+        <option name="command" value="--global-response-templating --verbose" />
+        <option name="containerName" value="wiremock-extension-state-test" />
+        <option name="portBindings">
+          <list>
+            <DockerPortBindingImpl>
+              <option name="containerPort" value="8080" />
+              <option name="hostPort" value="8080" />
+            </DockerPortBindingImpl>
+          </list>
+        </option>
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/var/wiremock/extensions" />
+              <option name="hostPath" value="$PROJECT_DIR$/build/libs" />
+              <option name="readOnly" value="true" />
+            </DockerVolumeBindingImpl>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/home/wiremock" />
+              <option name="hostPath" value="$PROJECT_DIR$/src/test/resources/remoteloader/" />
+            </DockerVolumeBindingImpl>
+          </list>
+        </option>
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,17 @@
+# Testing docker
+
+Build and start the container:
+
+```bash
+./gradlew clean build -x test
+```
+
+```bash
+docker run -it --rm \
+-p 8080:8080 \
+--name wiremock \
+-v $PWD/build/libs:/var/wiremock/extensions \
+-v $PWD/src/test/resources/remoteloader:/home/wiremock \
+wiremock/wiremock:3x \
+--global-response-templating
+```

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ docker run -it --rm \
 -p 8080:8080 \
 --name wiremock \
 -v $PWD/extensions:/var/wiremock/extensions \
-wiremock/wiremock:3x
+wiremock/wiremock:3x \
+-- --global-response-templating
 ```
 
 ## Record a state

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ shadowJar {
         from("shadowjar/resources") {}
     }
 
-    relocate "com.github.ben-manes.caffeine", 'wiremock.org.extensions.state.caffeine'
-    relocate "com.github.jknack", 'wiremock.org.extensions.state.jknack'
+    relocate "com.github.ben-manes.caffeine", 'wiremock.com.github.ben-manes.caffeine'
+    relocate "com.github.jknack", 'wiremock.com.github.jknack'
 
 
     dependencies {

--- a/docker_container_test.http
+++ b/docker_container_test.http
@@ -1,0 +1,47 @@
+### empty get
+
+GET http://localhost:8080/queue/myqueue
+
+> {%
+    client.test("Request executed successfully", function () {
+        const status = response.status;
+        client.assert(status === 200, "expected response status 200 but received '" + status + "'");
+    });
+    client.test("Response content-type is json", function() {
+        const type = response.contentType.mimeType;
+        client.assert(type === "application/json", "Expected 'application/json' but received '" + type + "'");
+    });
+    client.test("empty list is returned", function () {
+        const item = response.body.item;
+        client.assert(item === "no data", "response is not an empty list: '" + item + "'");
+    });
+%}
+
+### POST entry
+
+POST http://localhost:8080/queue/myqueue/abdcef
+
+> {%
+    client.test("Request executed successfully", function () {
+        client.assert(response.status === 200, "response status is not 200");
+    });
+%}
+
+### filled get
+
+GET http://localhost:8080/queue/myqueue
+
+> {%
+    client.test("Request executed successfully", function () {
+        const status = response.status;
+        client.assert(status === 200, "expected response status 200 but received '" + status + "'");
+    });
+    client.test("Response content-type is json", function() {
+        const type = response.contentType.mimeType;
+        client.assert(type === "application/json", "Expected 'application/json' but received '" + type + "'");
+    });
+    client.test("list with correct  is returned", function () {
+        const item = response.body.item;
+        client.assert(item === 'abdcef', "response does not contain queue item but is: '" + item + "'");
+    });
+%}


### PR DESCRIPTION
- handlebars relocation matches wiremock standalone
- added IntelliJ run configuration for docker
- added markdown helper for docker test
- added http file for docker test


## References

#36 

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
