### PR TITLE
Adding matcher for property existence/non-existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,36 @@ behavior for requests with and without a matching context. The parameter support
 }
 ```
 
+### Property existence match
+
+In addition to the existence of a context, you can check for the existence or absence of a property
+within that context. The following matchers are available:
+
+- `hasProperty`
+- `hasNotProperty`
+
+As for other matchers, templating is supported.
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/test/[^\/]+/[^\/]+",
+    "customMatcher": {
+      "name": "state-matcher",
+      "parameters": {
+        "hasContext": "{{request.pathSegments.[1]}}",
+        "hasProperty": "{{request.pathSegments.[2]}}"
+      }
+    }
+  },
+  "response": {
+    "status": 200
+  }
+}
+```
+
+
 ### Context update count match
 
 Whenever the serve event listener `recordState` is processed, the internal context update counter is increased. The number can be used
@@ -626,7 +656,7 @@ for request matching as well. The following matchers are available:
 - `updateCountLessThan`
 - `updateCountMoreThan`
 
-As for other matchers, templating is supported.
+As for other matchers, templating is supported. In case the provided value for this check is not numeric, it is handled as non-matching. No error will be reported or logged.
 
 ```json
 {
@@ -656,7 +686,7 @@ for request matching as well. The following matchers are available:
 - `listSizeLessThan`
 - `listSizeMoreThan`
 
-As for other matchers, templating is supported.
+As for other matchers, templating is supported. In case the provided value for this check is not numeric, it is handled as non-matching. No error will be reported or logged.
 
 ```json
 {

--- a/src/main/java/org/wiremock/extensions/state/internal/StateRequestMatcherParameters.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/StateRequestMatcherParameters.java
@@ -1,0 +1,80 @@
+package org.wiremock.extensions.state.internal;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StateRequestMatcherParameters {
+    String hasContext;
+
+    String hasNotContext;
+    String updateCountEqualTo;
+    String updateCountLessThan;
+    String updateCountMoreThan;
+    String listSizeEqualTo;
+    String listSizeLessThan;
+    String listSizeMoreThan;
+
+    public String getHasNotContext() {
+        return hasNotContext;
+    }
+
+    public void setHasNotContext(String hasNotContext) {
+        this.hasNotContext = hasNotContext;
+    }
+
+    public String getHasContext() {
+        return hasContext;
+    }
+
+    public void setHasContext(String hasContext) {
+        this.hasContext = hasContext;
+    }
+
+    public String getUpdateCountEqualTo() {
+        return updateCountEqualTo;
+    }
+
+    public void setUpdateCountEqualTo(String updateCountEqualTo) {
+        this.updateCountEqualTo = updateCountEqualTo;
+    }
+
+    public String getUpdateCountLessThan() {
+        return updateCountLessThan;
+    }
+
+    public void setUpdateCountLessThan(String updateCountLessThan) {
+        this.updateCountLessThan = updateCountLessThan;
+    }
+
+    public String getUpdateCountMoreThan() {
+        return updateCountMoreThan;
+    }
+
+    public void setUpdateCountMoreThan(String updateCountMoreThan) {
+        this.updateCountMoreThan = updateCountMoreThan;
+    }
+
+    public String getListSizeEqualTo() {
+        return listSizeEqualTo;
+    }
+
+    public void setListSizeEqualTo(String listSizeEqualTo) {
+        this.listSizeEqualTo = listSizeEqualTo;
+    }
+
+    public String getListSizeLessThan() {
+        return listSizeLessThan;
+    }
+
+    public void setListSizeLessThan(String listSizeLessThan) {
+        this.listSizeLessThan = listSizeLessThan;
+    }
+
+    public String getListSizeMoreThan() {
+        return listSizeMoreThan;
+    }
+
+    public void setListSizeMoreThan(String listSizeMoreThan) {
+        this.listSizeMoreThan = listSizeMoreThan;
+    }
+}

--- a/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
@@ -39,6 +38,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class StateRequestMatcherTest extends AbstractTestBase {
 
@@ -47,45 +47,8 @@ class StateRequestMatcherTest extends AbstractTestBase {
     @BeforeEach
     void setup() throws JsonProcessingException {
         createPostStub();
-        createGetStub();
+        createGetStubs();
         createDeleteStub();
-    }
-
-    @Test
-    void test_unknownContext_notFound() throws URISyntaxException {
-        String context = RandomStringUtils.randomAlphabetic(5);
-        getAndAssertContextMatcher(context, "all", HttpStatus.SC_NOT_FOUND, "context not found");
-    }
-
-
-    @Test
-    void test_findsContext_ok() throws URISyntaxException {
-        var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-        var context = postAndAssertContextValue(contextValue);
-        getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
-    }
-
-
-    @Test
-    void test_unknownContextWithOtherContextAvailable_notFound() throws URISyntaxException {
-        var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-        var context = postAndAssertContextValue(contextValue);
-        getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
-        getAndAssertContextMatcher(RandomStringUtils.randomAlphabetic(5), "all", HttpStatus.SC_NOT_FOUND, "context not found");
-    }
-
-    @Test
-    void test_multipleContexts_ok() throws URISyntaxException {
-        var contextValueOne = RandomStringUtils.randomAlphabetic(5);
-        var contextValueTwo = RandomStringUtils.randomAlphabetic(5);
-
-        var contextOne = postAndAssertContextValue(contextValueOne);
-        var contextTwo = postAndAssertContextValue(contextValueTwo);
-
-        getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "2", "1");
-        getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
     }
 
     private void createDeleteStub() {
@@ -105,7 +68,7 @@ class StateRequestMatcherTest extends AbstractTestBase {
         );
     }
 
-    private void createGetStub() throws JsonProcessingException {
+    private void createGetStubs() throws JsonProcessingException {
         wm.stubFor(
             get(urlPathMatching(TEST_URL + "/all/[^/]+"))
                 .andMatching("state-matcher", Parameters.one("hasContext", "{{request.pathSegments.[2]}}"))
@@ -134,17 +97,19 @@ class StateRequestMatcherTest extends AbstractTestBase {
                         )
                 )
         );
-        createGetStub("updateCountEqualTo");
-        createGetStub("updateCountLessThan");
-        createGetStub("updateCountMoreThan");
-        createGetStub("listSizeEqualTo");
-        createGetStub("listSizeLessThan");
-        createGetStub("listSizeMoreThan");
+        createGetStubs("hasProperty");
+        createGetStubs("hasNotProperty");
+        createGetStubs("updateCountEqualTo");
+        createGetStubs("updateCountLessThan");
+        createGetStubs("updateCountMoreThan");
+        createGetStubs("listSizeEqualTo");
+        createGetStubs("listSizeLessThan");
+        createGetStubs("listSizeMoreThan");
     }
 
-    private void createGetStub(String check) throws JsonProcessingException {
+    private void createGetStubs(String check) throws JsonProcessingException {
         wm.stubFor(
-            get(urlPathMatching(TEST_URL + "/" + check + "/\\d+/[^/]+"))
+            get(urlPathMatching(TEST_URL + "/" + check + "/[^/]+/[^/]+"))
                 .andMatching("state-matcher", Parameters.from(
                     Map.of(
                         "hasContext", "{{request.pathSegments.[3]}}",
@@ -221,31 +186,31 @@ class StateRequestMatcherTest extends AbstractTestBase {
         );
     }
 
-    private ValidatableResponse getAndAssertContextMatcher(String context, String path, int httpStatus, String statusValue) throws URISyntaxException {
+    private ValidatableResponse getAndAssertContextMatcher(String context, String path, int httpStatus, String statusValue) {
         return getAndAssertContextMatcher(context, path, httpStatus)
             .body("status", equalTo(statusValue));
     }
 
-    private ValidatableResponse getAndAssertContextMatcher(String context, String path, int httpStatus) throws URISyntaxException {
+    private ValidatableResponse getAndAssertContextMatcher(String context, String path, int httpStatus) {
         return given()
             .accept(ContentType.JSON)
             .accept(ContentType.TEXT)
-            .get(new URI(String.format("%s%s/%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), TEST_URL, path, context)))
+            .get(assertDoesNotThrow(() -> new URI(String.format("%s%s/%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), TEST_URL, path, context))))
             .then()
             .statusCode(httpStatus);
     }
 
-    private void getAndAssertContextMatcher(String context, String path, int httpStatus, String statusValue, String updateCount, String listSize) throws URISyntaxException {
+    private void getAndAssertContextMatcher(String context, String path, int httpStatus, String statusValue, String updateCount, String listSize) {
         getAndAssertContextMatcher(context, path, httpStatus, statusValue)
             .body("updateCount", equalTo(updateCount))
             .body("listSize", equalTo(listSize));
     }
 
-    private String postAndAssertContextValue(String contextValue) throws URISyntaxException {
+    private String postAndAssertContextValue(String contextValue) {
         var context = given()
             .accept(ContentType.JSON)
             .body(Map.of("contextValue", contextValue))
-            .post(new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_URL))
+            .post(assertDoesNotThrow(() -> new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_URL)))
             .then()
             .statusCode(HttpStatus.SC_OK)
             .body("id", Matchers.notNullValue())
@@ -260,11 +225,11 @@ class StateRequestMatcherTest extends AbstractTestBase {
         return context;
     }
 
-    private String postAndAssertContextValue(String contextName, String contextValue) throws URISyntaxException {
+    private String postAndAssertContextValue(String contextName, String contextValue) {
         var context = given()
             .accept(ContentType.JSON)
             .body(Map.of("contextValue", contextValue, "id", contextName))
-            .post(new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_URL + "/" + contextName))
+            .post(assertDoesNotThrow(() -> new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_URL + "/" + contextName)))
             .then()
             .statusCode(HttpStatus.SC_OK)
             .body("id", Matchers.notNullValue())
@@ -280,85 +245,36 @@ class StateRequestMatcherTest extends AbstractTestBase {
     }
 
     @Nested
-    public class UpdateCount {
+    public class HasNotContext {
         @Test
-        void test_countAndSizeIncreased_ok() throws URISyntaxException {
+        void test_unknownContext_notFound() {
+            String context = RandomStringUtils.randomAlphabetic(5);
+            getAndAssertContextMatcher(context, "all", HttpStatus.SC_NOT_FOUND, "context not found");
+        }
+    }
+
+    @Nested
+    public class hasContext {
+
+        @Test
+        void test_findsContext_ok() {
             var contextValue = RandomStringUtils.randomAlphabetic(5);
 
             var context = postAndAssertContextValue(contextValue);
             getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
-            postAndAssertContextValue(context, contextValue);
-            getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "4", "2");
         }
 
         @Test
-        void test_updateCountEqualTo_ok() throws URISyntaxException {
+        void test_unknownContextWithOtherContextAvailable_notFound() {
             var contextValue = RandomStringUtils.randomAlphabetic(5);
 
             var context = postAndAssertContextValue(contextValue);
-            postAndAssertContextValue(context, contextValue);
-            postAndAssertContextValue(context, contextValue);
-            getAndAssertContextMatcher(context, "updateCountEqualTo/6", HttpStatus.SC_OK, "context found", "6", "3");
-            getAndAssertContextMatcher(context, "updateCountEqualTo/2", HttpStatus.SC_NOT_FOUND);
+            getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
+            getAndAssertContextMatcher(RandomStringUtils.randomAlphabetic(5), "all", HttpStatus.SC_NOT_FOUND, "context not found");
         }
 
         @Test
-        void test_listSizeEqualTo_ok() throws URISyntaxException {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            var context = postAndAssertContextValue(contextValue);
-            postAndAssertContextValue(context, contextValue);
-            postAndAssertContextValue(context, contextValue);
-            getAndAssertContextMatcher(context, "listSizeEqualTo/3", HttpStatus.SC_OK, "context found", "6", "3");
-            getAndAssertContextMatcher(context, "listSizeEqualTo/2", HttpStatus.SC_NOT_FOUND);
-        }
-
-        @Test
-        void test_updateCountLessThan_ok() throws URISyntaxException {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            var context = postAndAssertContextValue(contextValue);
-            postAndAssertContextValue(context, contextValue);
-            postAndAssertContextValue(context, contextValue);
-            getAndAssertContextMatcher(context, "updateCountLessThan/7", HttpStatus.SC_OK, "context found", "6", "3");
-            getAndAssertContextMatcher(context, "updateCountLessThan/6", HttpStatus.SC_NOT_FOUND);
-        }
-
-        @Test
-        void test_listSizeLessThan_ok() throws URISyntaxException {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            var context = postAndAssertContextValue(contextValue);
-            postAndAssertContextValue(context, contextValue);
-            postAndAssertContextValue(context, contextValue);
-            getAndAssertContextMatcher(context, "listSizeLessThan/4", HttpStatus.SC_OK, "context found", "6", "3");
-            getAndAssertContextMatcher(context, "listSizeLessThan/3", HttpStatus.SC_NOT_FOUND);
-        }
-
-        @Test
-        void test_updateCountMoreThan_ok() throws URISyntaxException {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            var context = postAndAssertContextValue(contextValue);
-            postAndAssertContextValue(context, contextValue);
-            postAndAssertContextValue(context, contextValue);
-            getAndAssertContextMatcher(context, "updateCountMoreThan/5", HttpStatus.SC_OK, "context found", "6", "3");
-            getAndAssertContextMatcher(context, "updateCountMoreThan/6", HttpStatus.SC_NOT_FOUND);
-        }
-
-        @Test
-        void test_listSizeMoreThan_ok() throws URISyntaxException {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            var context = postAndAssertContextValue(contextValue);
-            postAndAssertContextValue(context, contextValue);
-            postAndAssertContextValue(context, contextValue);
-            getAndAssertContextMatcher(context, "listSizeMoreThan/2", HttpStatus.SC_OK, "context found", "6", "3");
-            getAndAssertContextMatcher(context, "listSizeMoreThan/3", HttpStatus.SC_NOT_FOUND);
-        }
-
-        @Test
-        void test_multipleContexts_updateAndSizeIncreasedIndividually_ok() throws URISyntaxException {
+        void test_multipleContexts_ok() {
             var contextValueOne = RandomStringUtils.randomAlphabetic(5);
             var contextValueTwo = RandomStringUtils.randomAlphabetic(5);
 
@@ -367,14 +283,183 @@ class StateRequestMatcherTest extends AbstractTestBase {
 
             getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "2", "1");
             getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
-
-            postAndAssertContextValue(contextOne, contextValueOne);
-            getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "4", "2");
-            getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
-
-            postAndAssertContextValue(contextTwo, contextValueTwo);
-            getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "4", "2");
-            getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "4", "2");
         }
+
+        @Nested
+        public class Property {
+            @Test
+            void test_hasProperty_propertyDoesNotExist_fail() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "hasProperty/unknownValue", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_hasProperty_propertyExists_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "hasProperty/stateValue", HttpStatus.SC_OK, "context found", "2", "1");
+            }
+
+            @Test
+            void test_hasNotProperty_propertyExists_fail() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "hasNotProperty/stateValue", HttpStatus.SC_NOT_FOUND);
+
+            }
+
+            @Test
+            void test_hasNotProperty_propertyDoesNotExists_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "hasNotProperty/unknownValue", HttpStatus.SC_OK, "context found", "2", "1");
+
+            }
+        }
+
+        @Nested
+        public class UpdateCount {
+            @Test
+            void test_countAndSizeIncreased_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
+                postAndAssertContextValue(context, contextValue);
+                getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "4", "2");
+            }
+
+            @Test
+            void test_updateCountEqualTo_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, contextValue);
+                postAndAssertContextValue(context, contextValue);
+                getAndAssertContextMatcher(context, "updateCountEqualTo/6", HttpStatus.SC_OK, "context found", "6", "3");
+                getAndAssertContextMatcher(context, "updateCountEqualTo/2", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_listSizeEqualTo_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, contextValue);
+                postAndAssertContextValue(context, contextValue);
+                getAndAssertContextMatcher(context, "listSizeEqualTo/3", HttpStatus.SC_OK, "context found", "6", "3");
+                getAndAssertContextMatcher(context, "listSizeEqualTo/2", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_listSizeEqualTo_invalidInput_fail() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "listSizeEqualTo/invalid", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_updateCountLessThan_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, contextValue);
+                postAndAssertContextValue(context, contextValue);
+                getAndAssertContextMatcher(context, "updateCountLessThan/7", HttpStatus.SC_OK, "context found", "6", "3");
+                getAndAssertContextMatcher(context, "updateCountLessThan/6", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_updateCountLessThan_invalidInput_fail() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "updateCountLessThan/invalid", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_listSizeLessThan_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, contextValue);
+                postAndAssertContextValue(context, contextValue);
+                getAndAssertContextMatcher(context, "listSizeLessThan/4", HttpStatus.SC_OK, "context found", "6", "3");
+                getAndAssertContextMatcher(context, "listSizeLessThan/3", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_listSizeLessThan_invalidInput_fail() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "listSizeLessThan/invalid", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_updateCountMoreThan_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, contextValue);
+                postAndAssertContextValue(context, contextValue);
+                getAndAssertContextMatcher(context, "updateCountMoreThan/5", HttpStatus.SC_OK, "context found", "6", "3");
+                getAndAssertContextMatcher(context, "updateCountMoreThan/6", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_updateCountMoreThan_invalidInput_fail() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "updateCountMoreThan/invalid", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_listSizeMoreThan_ok() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, contextValue);
+                postAndAssertContextValue(context, contextValue);
+                getAndAssertContextMatcher(context, "listSizeMoreThan/2", HttpStatus.SC_OK, "context found", "6", "3");
+                getAndAssertContextMatcher(context, "listSizeMoreThan/3", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_listSizeMoreThan_invalidInput_fail() {
+                var contextValue = RandomStringUtils.randomAlphabetic(5);
+
+                var context = postAndAssertContextValue(contextValue);
+                getAndAssertContextMatcher(context, "listSizeMoreThan/invalid", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @Test
+            void test_multipleContexts_updateAndSizeIncreasedIndividually_ok() {
+                var contextValueOne = RandomStringUtils.randomAlphabetic(5);
+                var contextValueTwo = RandomStringUtils.randomAlphabetic(5);
+
+                var contextOne = postAndAssertContextValue(contextValueOne);
+                var contextTwo = postAndAssertContextValue(contextValueTwo);
+
+                getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "2", "1");
+                getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
+
+                postAndAssertContextValue(contextOne, contextValueOne);
+                getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "4", "2");
+                getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
+
+                postAndAssertContextValue(contextTwo, contextValueTwo);
+                getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "4", "2");
+                getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "4", "2");
+            }
+        }
+
     }
 }


### PR DESCRIPTION
- corrected handling of all matchers using numbers: a non-numeric value will now result in a non-match (no error logs will be posted as they might be plenty based on the stubs that are configured)

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
