### PR TITLE
Use proper defaults when properties or contexts are not missing

### DIFF
--- a/src/main/java/org/wiremock/extensions/state/extensions/RecordStateEventListener.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/RecordStateEventListener.java
@@ -125,5 +125,4 @@ public class RecordStateEventListener implements ServeEventListener, StateExtens
     private String renderTemplate(Object context, String value) {
         return templateEngine.getUncachedTemplate(value).apply(context);
     }
-
 }

--- a/src/main/java/org/wiremock/extensions/state/internal/ContextManager.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/ContextManager.java
@@ -63,6 +63,13 @@ public class ContextManager {
         }
     }
 
+    public void deleteAllContexts() {
+        synchronized (store) {
+            logger().info("allContexts", "deleted");
+            store.clear();
+        }
+    }
+
     public Long createOrUpdateContextState(String contextName, Map<String, String> properties) {
         synchronized (store) {
             var context = store.get(contextName)

--- a/src/main/java/org/wiremock/extensions/state/internal/ExtensionLogger.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/ExtensionLogger.java
@@ -1,15 +1,11 @@
 package org.wiremock.extensions.state.internal;
 
-import com.github.tomakehurst.wiremock.common.Notifier;
-
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 
 public class ExtensionLogger {
 
-    private static Notifier notifier;
-
     private ExtensionLogger() {
-        notifier = notifier();
+
     }
 
     public static ExtensionLogger logger() {
@@ -17,19 +13,19 @@ public class ExtensionLogger {
     }
 
     public void info(Context context, String message) {
-        notifier.info(buildMessage(context.getContextName(), message));
+        notifier().info(buildMessage(context.getContextName(), message));
     }
 
     public void error(Context context, String message) {
-        notifier.error(buildMessage(context.getContextName(), message));
+        notifier().error(buildMessage(context.getContextName(), message));
     }
 
     public void info(String contextName, String message) {
-        notifier.info(buildMessage(contextName, message));
+        notifier().info(buildMessage(contextName, message));
     }
 
     public void error(String contextName, String message) {
-        notifier.error(buildMessage(contextName, message));
+        notifier().error(buildMessage(contextName, message));
     }
 
     private String buildMessage(String contextName, String message) {

--- a/src/test/java/org/wiremock/extensions/state/functionality/AbstractTestBase.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/AbstractTestBase.java
@@ -60,6 +60,7 @@ public class AbstractTestBase {
     @BeforeEach
     void setupBase() {
         wm.resetAll();
+        contextManager.deleteAllContexts();
     }
 
     protected void assertContextNumUpdates(String context, int expected) {

--- a/src/test/java/org/wiremock/extensions/state/functionality/StateTemplateHelperProviderExtensionTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/StateTemplateHelperProviderExtensionTest.java
@@ -20,478 +20,618 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
-import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class StateTemplateHelperProviderExtensionTest extends AbstractTestBase {
 
-    @Test
-    void test_noExtensionUsage_ok() throws JsonProcessingException, URISyntaxException {
-        var runtimeInfo = wm.getRuntimeInfo();
-        wm.stubFor(
-            post(urlEqualTo("/"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            mapper.readTree(
-                                mapper.writeValueAsString(Map.of("testKey", "testValue")))
-                        )
-                )
-        );
-
+    private void postContext(String contextName, Map<String, Object> body) {
+        var preparedBody = new HashMap<>(body);
+        preparedBody.put("contextName", contextName);
         given()
+            .contentType(ContentType.JSON)
+            .body(preparedBody)
+            .post(assertDoesNotThrow(() -> new URI(String.format("%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), "contexturl"))))
+            .then()
+            .statusCode(HttpStatus.SC_OK);
+    }
+
+    private void getContext(String contextName, Consumer<Map<String, Object>> assertion) {
+        Map<String, Object> result = given()
             .accept(ContentType.JSON)
-            .post(new URI(runtimeInfo.getHttpBaseUrl() + "/"))
+            .get(assertDoesNotThrow(() -> new URI(String.format("%s/%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), "contexturl", contextName))))
             .then()
             .statusCode(HttpStatus.SC_OK)
-            .body("testKey", equalTo("testValue"));
+            .extract().body().as(mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class));
+        assertion.accept(result);
     }
 
-    @Test
-    void test_unknownContext_fail() {
-        createPostStub();
-        createGetStub();
-
-        String context = RandomStringUtils.randomAlphabetic(5);
-        getAndAssertContextValue(
-            "state",
-            context,
-            String.format("[ERROR: No state for context '%s', property 'stateValueOne' found]", context),
-            String.format("[ERROR: No state for context '%s', property 'stateValueTwo' found]", context),
-            String.format("[ERROR: No state for context '%s', property 'listSize' found]", context)
-        );
+    private void getContextList(String contextName, Consumer<List<Map<String, Object>>> assertion) {
+        List<Map<String, Object>> result = given()
+            .accept(ContentType.JSON)
+            .get(assertDoesNotThrow(() -> new URI(String.format("%s/%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), "contexturl", contextName))))
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract().body().as(
+                mapper.getTypeFactory().constructCollectionLikeType(ArrayList.class,
+                    mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class))
+            );
+        assertion.accept(result);
     }
 
-    @Test
-    void test_unknownContext_useDefault() {
-        createPostStub();
-        createGetStub();
-
-        String context = RandomStringUtils.randomAlphabetic(5);
-        getAndAssertContextValue(
-            "state/default",
-            context,
-            "defaultStateValueOne",
-            "defaultStateValueTwo",
-            "defaultListSize"
-        );
-    }
-
-    @Test
-    void test_unknownProperty_fail() throws JsonProcessingException {
-        var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-        createPostStub();
+    private void createContextListPostStub(Map<String, Object> stateConfiguration) {
         wm.stubFor(
-            get(urlPathMatching("/state/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            mapper.readTree(
-                                mapper.writeValueAsString(Map.of(
-                                    "valueOne", "{{state context=request.pathSegments.[1] property='unknownValue'}}",
-                                    "valueTwo", "{{state context=request.pathSegments.[1] property='unknownValue'}}",
-                                    "unknown", "{{state context=request.pathSegments.[1] property='unknown' default='defaultUnknown'}}"
-                                )))
-                        )
-                )
-        );
-
-        postAndAssertContextValue("state", contextValue, "one");
-        getAndAssertContextValue(
-            "state",
-            contextValue,
-            String.format("[ERROR: No state for context '%s', property 'unknownValue' found]", contextValue),
-            String.format("[ERROR: No state for context '%s', property 'unknownValue' found]", contextValue),
-            null
-        );
-    }
-
-    private void createGetStub() {
-        wm.stubFor(
-            get(urlPathMatching("/state/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            Json.node(
-                                Json.write(
-                                    Map.of(
-                                        "valueOne", "{{state context=request.pathSegments.[1] property='stateValueOne'}}",
-                                        "valueTwo", "{{state context=request.pathSegments.[1] property='stateValueTwo'}}",
-                                        "listSize", "{{state context=request.pathSegments.[1] property='listSize'}}",
-                                        "unknown", "{{state context=request.pathSegments.[1] property='unknown' default='defaultUnknown'}}"
-                                    )
-                                )
-                            )
-                        )
-                )
-        );
-        wm.stubFor(
-            get(urlPathMatching("/state/default/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            Json.node(
-                                Json.write(
-                                    Map.of(
-                                        "valueOne", "{{state context=request.pathSegments.[2] property='stateValueOne' default='defaultStateValueOne'}}",
-                                        "valueTwo", "{{state context=request.pathSegments.[2] property='stateValueTwo'  default='defaultStateValueTwo'}}",
-                                        "listSize", "{{state context=request.pathSegments.[2] property='listSize' default='defaultListSize'}}",
-                                        "unknown", "{{state context=request.pathSegments.[2] property='unknown' default='defaultUnknown'}}"
-                                    )
-                                )
-                            )
-                        )
-                )
-        );
-        wm.stubFor(
-            get(urlPathMatching("/full/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withBody("{{{state context=request.pathSegments.[1] property='stateBody'}}}")
-                )
-        );
-        wm.stubFor(
-            get(urlPathMatching("/list/[^/]+/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            Json.node(
-                                Json.write(
-                                    Map.of(
-                                        "valueOne", "{{state context=request.pathSegments.[2] list=(join '[' request.pathSegments.[1] '].stateValueOne' '')}}",
-                                        "valueTwo", "{{state context=request.pathSegments.[2] list=(join '[' request.pathSegments.[1] '].stateValueTwo' '')}}",
-                                        "listSize", "{{state context=request.pathSegments.[2] property='listSize'}}",
-                                        "unknown", "{{state context=request.pathSegments.[2] property='unknown' default='defaultUnknown'}}"
-                                    )
-                                )
-                            )
-                        )
-                )
-        );
-
-        wm.stubFor(
-            get(urlPathMatching("/list/allNoDefault/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withBody(
-                            "[\n" +
-                                "{{# each (state context=request.pathSegments.[2] property='list') }}" +
-                                "  {\n" +
-                                "  }{{#unless @last}},{{/unless}}\n" +
-                                "{{/each}}" +
-                                "]"
-                        )
-                )
-        );
-
-        wm.stubFor(
-            get(urlPathMatching("/list/all/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withBody(
-                            "[\n" +
-                                "{{#each (state context=request.pathSegments.[2] property='list' default='[{\"stateValueOne\": \"defaultValueOne\",\"stateValueTwo\": \"defaultValueTwo\"}]') }}" +
-                                "  {\n" +
-                                "    \"valueOne\": \"{{stateValueOne}}\",\n" +
-                                "    \"valueTwo\": \"{{stateValueTwo}}\"" +
-                                "  }{{#unless @last}},{{/unless}}\n" +
-                                "{{/each}}" +
-                                "]"
-                        )
-                )
-        );
-
-        wm.stubFor(
-            get(urlPathMatching("/list/default/[^/]+/[^/]+"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            Json.node(
-                                Json.write(
-                                    Map.of(
-                                        "valueOne", "{{state context=request.pathSegments.[3] list=(join '[' request.pathSegments.[2] '].stateValueOne' '') default='defaultStateValueOne'}}",
-                                        "valueTwo", "{{state context=request.pathSegments.[3] list=(join '[' request.pathSegments.[2] '].stateValueTwo' '') default='defaultStateValueTwo'}}",
-                                        "listSize", "{{state context=request.pathSegments.[3] property='listSize'  default='defaultListSize'}}",
-                                        "unknown", "{{state context=request.pathSegments.[3] property='unknown' default='defaultUnknown'}}"
-                                    )
-                                )
-                            )
-                        )
-                )
-        );
-    }
-
-    private void createPostStub() {
-        wm.stubFor(
-            post(urlEqualTo("/state"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(Json.node(Json.write(Map.of(
-                                        "id", "{{randomValue length=32 type='ALPHANUMERIC' uppercase=false}}",
-                                        "contextValue", "{{jsonPath request.body '$.contextValueOne'}}",
-                                        "other", "randomValue length=32 type='ALPHANUMERIC'"
-                                    )
-                                )
-                            )
-                        )
-                )
+            post(urlEqualTo("/contexturl"))
+                .willReturn(WireMock.ok().withHeader("content-type", "application/json"))
                 .withServeEventListener(
                     "recordState",
                     Parameters.from(
                         Map.of(
-                            "context", "{{jsonPath request.body '$.contextValueOne'}}",
-                            "state", Map.of(
-                                "stateValueOne", "{{jsonPath request.body '$.contextValueOne'}}",
-                                "stateValueTwo", "{{jsonPath request.body '$.contextValueTwo'}}",
-                                "stateBody", "{{{jsonPath response.body '$'}}}"
-                            )
-                        )
-                    )
-                )
-        );
-        wm.stubFor(
-            post(urlEqualTo("/list"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(Json.node(
-                                Json.write(
-                                    Map.of(
-                                        "id", "{{randomValue length=32 type='ALPHANUMERIC' uppercase=false}}",
-                                        "contextValue", "{{jsonPath request.body '$.contextValueOne'}}",
-                                        "other", "randomValue length=32 type='ALPHANUMERIC'"
-                                    )
-                                )
-                            )
-                        )
-                )
-                .withServeEventListener(
-                    "recordState",
-                    Parameters.from(
-                        Map.of(
-                            "context", "{{jsonPath request.body '$.contextValueOne'}}",
-                            "list", Map.of(
-                                "addLast", Map.of(
-                                    "stateValueOne", "{{jsonPath request.body '$.contextValueOne'}}",
-                                    "stateValueTwo", "{{jsonPath request.body '$.contextValueTwo'}}",
-                                    "stateBody", "{{{jsonPath response.body '$'}}}"
-                                )
-                            )
+                            "context", "{{jsonPath request.body '$.contextName'}}",
+                            "list", Map.of("addLast", stateConfiguration)
                         )
                     )
                 )
         );
     }
 
-    private void getAndAssertContextValue(String path, String context, String valueOne, String valueTwo, String listSize) {
-        getAndAssertOk(path, context)
-            .body("valueOne", equalTo(valueOne))
-            .body("valueTwo", equalTo(valueTwo))
-            .body("listSize", equalTo(listSize))
-            .body("unknown", equalTo("defaultUnknown"))
-            .body("other", nullValue());
-    }
-
-    private ValidatableResponse getAndAssertOk(String path, String context) {
-        return given()
-            .accept(ContentType.JSON)
-            .get(assertDoesNotThrow(() -> new URI(String.format("%s/%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), path, context))))
-            .then()
-            .statusCode(HttpStatus.SC_OK);
-    }
-
-    private void getAndAssertFullBody(String contextValue) {
-        given()
-            .accept(ContentType.JSON)
-            .get(assertDoesNotThrow(() -> new URI(String.format("%s/%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), "full", contextValue))))
-            .then()
-            .statusCode(HttpStatus.SC_OK)
-            .body("contextValue", equalTo(contextValue))
-            .body("other", notNullValue())
-            .body("value", nullValue());
-    }
-
-    private void postAndAssertContextValue(String path, String contextValueOne, String contextValueTwo) {
-        given()
-            .accept(ContentType.JSON)
-            .body(Map.of(
-                    "contextValueOne", contextValueOne,
-                    "contextValueTwo", contextValueTwo
+    private void createContextGetStub(Map<String, String> body) {
+        wm.stubFor(
+            get(urlPathMatching("/contexturl/[^/]+"))
+                .willReturn(
+                    WireMock.ok()
+                        .withHeader("content-type", "application/json")
+                        .withJsonBody(Json.node(Json.write(body)))
                 )
-            )
-            .post(assertDoesNotThrow(() -> new URI(wm.getRuntimeInfo().getHttpBaseUrl() + "/" + path)))
-            .then()
-            .statusCode(HttpStatus.SC_OK);
+        );
     }
 
-    @Nested
-    public class Property {
-
-        @BeforeEach
-        void setup() {
-            createPostStub();
-            createGetStub();
-        }
-
-        @Test
-        void test_returnsStateFromPreviousRequest_ok() {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            postAndAssertContextValue("state", contextValue, "one");
-            getAndAssertContextValue("state", contextValue, contextValue, "one", "0");
-        }
-
-        @Test
-        void test_defaults_returnsStateFromPreviousRequest_ok() {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            postAndAssertContextValue("state", contextValue, "one");
-            getAndAssertContextValue("state/default", contextValue, contextValue, "one", "0");
-        }
-
-        @Test
-        void test_returnsFullBodyFromPreviousRequest_ok() {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            postAndAssertContextValue("state", contextValue, "one");
-            getAndAssertFullBody(contextValue);
-        }
-
-        @Test
-        void test_differentStatesSupported_ok() {
-            var contextValueOne = RandomStringUtils.randomAlphabetic(5);
-            var contextValueTwo = RandomStringUtils.randomAlphabetic(5);
-
-            postAndAssertContextValue("state", contextValueOne, "one");
-            postAndAssertContextValue("state", contextValueTwo, "one");
-            getAndAssertContextValue("state", contextValueOne, contextValueOne, "one", "0");
-            getAndAssertContextValue("state", contextValueTwo, contextValueTwo, "one", "0");
-        }
-
-
+    private void createContextGetStub(String body) {
+        wm.stubFor(
+            get(urlPathMatching("/contexturl/[^/]+"))
+                .willReturn(
+                    WireMock.ok()
+                        .withHeader("content-type", "application/json")
+                        .withBody(body)
+                )
+        );
     }
 
+    private void createContextStatePostStub(Map<String, Object> stateConfiguration) {
+
+        wm.stubFor(
+            post(urlEqualTo("/contexturl"))
+                .willReturn(WireMock.ok().withHeader("content-type", "application/json"))
+                .withServeEventListener(
+                    "recordState",
+                    Parameters.from(
+                        Map.of(
+                            "context", "{{jsonPath request.body '$.contextName'}}",
+                            "state", stateConfiguration
+                        )
+                    )
+                )
+        );
+    }
+
+    private void createContextGetStubWithBodyFile(String file) {
+        wm.stubFor(
+            get(urlPathMatching("/contexturl/[^/]+"))
+                .willReturn(
+                    WireMock.ok()
+                        .withHeader("content-type", "application/json")
+                        .withBodyFile("StateTemplateHelperProviderExtensionTest/" + file)
+                )
+        );
+    }
+
+    @DisplayName("with no extension usage")
     @Nested
-    public class List {
+    public class NoExtension {
 
-        private final String contextValue = RandomStringUtils.randomAlphabetic(5);
-
-        @BeforeEach
-        void setup() {
-            createPostStub();
-            createGetStub();
-        }
-
+        @DisplayName("does not impact response creation or stub matching")
         @Test
-        void test_returnsListElement_oneItem_ok() {
-            postAndAssertContextValue("list", contextValue, "one");
+        public void test_noExtensionUsage_ok() throws JsonProcessingException, URISyntaxException {
+            var runtimeInfo = wm.getRuntimeInfo();
+            wm.stubFor(
+                post(urlEqualTo("/"))
+                    .willReturn(
+                        WireMock.ok()
+                            .withHeader("content-type", "application/json")
+                            .withJsonBody(
+                                mapper.readTree(
+                                    mapper.writeValueAsString(Map.of("testKey", "testValue")))
+                            )
+                    )
+            );
 
-            getAndAssertContextValue("list/0", contextValue, contextValue, "one", "1");
+            given()
+                .accept(ContentType.JSON)
+                .post(new URI(runtimeInfo.getHttpBaseUrl() + "/"))
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("testKey", equalTo("testValue"));
         }
+    }
 
+    @DisplayName("with missing context")
+    @Nested
+    public class MissingContext {
+
+        private final String contextName = "unknownContext";
+
+        @DisplayName("when no default is specified returns empty string")
         @Test
-        void test_defaults_knownItem_ok() {
-            postAndAssertContextValue("list", contextValue, "one");
+        void test_hasDefaultEmptyString() {
+            createContextGetStub(Map.of("contextValue", "{{state context=request.pathSegments.[1] property='contextValue'}}"));
 
-            getAndAssertContextValue("list/default/0", contextValue, contextValue, "one", "1");
+            getContext(contextName, (result) -> assertThat(result).containsEntry("contextValue", ""));
         }
 
+        @DisplayName("when default is specified returns default")
         @Test
-        void test_defaults_unknownItem_ok() {
-            postAndAssertContextValue("list", contextValue, "one");
+        void test_usesDefault() {
+            createContextGetStub(Map.of("contextValue", "{{state context=request.pathSegments.[1] property='contextValue' default='aDefaultValue'}}"));
 
-            getAndAssertContextValue("list/default/1", contextValue, "defaultStateValueOne", "defaultStateValueTwo", "1");
+            getContext(contextName, (result) -> assertThat(result).containsEntry("contextValue", "aDefaultValue"));
         }
 
+        @DisplayName("no default allows creating null-return with handlebars")
         @Test
-        void test_returnsListElement_multipleItems_ok() {
-            postAndAssertContextValue("list", contextValue, "one");
-            postAndAssertContextValue("list", contextValue, "two");
-            postAndAssertContextValue("list", contextValue, "three");
+        void test_allowNull() {
+            createContextGetStubWithBodyFile("value_or_null.json");
 
-            getAndAssertContextValue("list/1", contextValue, contextValue, "two", "3");
+            getContext(contextName, (result) -> assertThat(result).containsEntry("contextValue", null));
         }
 
+        @DisplayName("no default allows creating ignore-return with handlebars")
         @Test
-        void test_returnsSingleListElement_lastItem_ok() {
-            postAndAssertContextValue("list", contextValue, "one");
-            postAndAssertContextValue("list", contextValue, "two");
-            postAndAssertContextValue("list", contextValue, "three");
+        void test_allowIgnore() {
+            createContextGetStubWithBodyFile("value_or_ignore.json");
 
-            getAndAssertContextValue("list/-1", contextValue, contextValue, "three", "3");
+            getContext(contextName, (result) -> assertThat(result).doesNotContainKey("contextValue"));
         }
 
+        @DisplayName("when accessing list property")
         @Nested
-        public class CompleteList {
+        public class FullList {
+            @DisplayName("interprets empty default")
             @Test
-            void test_returnsCompleteList_noContext_emptyList() {
-                getAndAssertOk("list/allNoDefault", contextValue)
-                    .body("$", Matchers.empty());
+            void test_listEmptyDefault() {
+                createContextGetStubWithBodyFile("list_with_empty_default.json");
+
+                getContextList(contextName, (result) -> assertThat(result).isEmpty());
             }
 
+            @DisplayName("interprets filled default")
             @Test
-            void test_returnsCompleteList_defaultFilled_ok() {
-                getAndAssertOk("list/all", contextValue)
-                    .body("$", hasSize(1))
-                    .body("[0].valueOne", equalTo("defaultValueOne"))
-                    .body("[0].valueTwo", equalTo("defaultValueTwo"));
+            void test_listFilledDefault() {
+                createContextGetStubWithBodyFile("list_with_filled_default.json");
+
+                getContextList(contextName, (result) -> assertThat(result).containsExactly(Map.of("listValue", "defaultListValue")));
             }
 
+            @DisplayName("has proper built-in default")
             @Test
-            void test_returnsCompleteList_emptyList_ok() {
-                postAndAssertContextValue("state", contextValue, "one");
+            void test_listNoDefault() {
+                createContextGetStubWithBodyFile("list_with_no_default.json");
 
-                getAndAssertContextValue("state", contextValue, contextValue, "one", "0");
-                getAndAssertOk("list/all", contextValue)
-                    .body("$", Matchers.empty());
+                getContextList(contextName, (result) -> assertThat(result).isEmpty());
+            }
+        }
+    }
+
+    @DisplayName("with missing property")
+    @Nested
+    public class MissingProperty {
+        private final String contextName = "knownContext";
+
+        @BeforeEach
+        public void setup() {
+            createContextStatePostStub(Map.of());
+            postContext(contextName, Map.of());
+            assertThat(contextManager.getContext(contextName)).isPresent();
+        }
+
+        @DisplayName("when no default is specified returns empty string")
+        @Test
+        void test_hasDefaultEmptyString() {
+            createContextGetStub(Map.of("contextValue", "{{state context=request.pathSegments.[1] property='contextValue'}}"));
+
+            getContext(contextName, (result) -> assertThat(result).containsEntry("contextValue", ""));
+        }
+
+        @DisplayName("when default is specified returns default")
+        @Test
+        void test_usesDefault() {
+            createContextGetStub(Map.of("contextValue", "{{state context=request.pathSegments.[1] property='contextValue' default='aDefaultValue'}}"));
+
+            getContext(contextName, (result) -> assertThat(result).containsEntry("contextValue", "aDefaultValue"));
+        }
+
+        @DisplayName("no default allows creating null-return with handlebars")
+        @Test
+        void test_allowNull() {
+            createContextGetStubWithBodyFile("value_or_null.json");
+
+            getContext(contextName, (result) -> assertThat(result).containsEntry("contextValue", null));
+        }
+
+        @DisplayName("no default allows creating ignore-return with handlebars")
+        @Test
+        void test_allowIgnore() {
+            createContextGetStubWithBodyFile("value_or_ignore.json");
+
+            getContext(contextName, (result) -> assertThat(result).doesNotContainKey("contextValue"));
+        }
+    }
+
+    @DisplayName("with missing list")
+    @Nested
+    public class MissingList {
+        private final String contextName = "knownContext";
+
+        @BeforeEach
+        public void setup() {
+            createContextStatePostStub(Map.of());
+            postContext(contextName, Map.of());
+            assertThat(contextManager.getContext(contextName)).isPresent();
+        }
+
+        @DisplayName("when accessing first element")
+        @Nested
+        public class FirstElement {
+
+            @DisplayName("when no default is specified returns empty string")
+            @Test
+            void test_hasDefaultEmptyString() {
+                createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[0].listValue'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listValue", ""));
             }
 
+            @DisplayName("when default is specified returns default")
             @Test
-            void test_returnsCompleteList_entries_ok() {
-                postAndAssertContextValue("list", contextValue, "one");
-                postAndAssertContextValue("list", contextValue, "two");
-                postAndAssertContextValue("list", contextValue, "three");
+            void test_usesDefault() {
+                createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] property='[0].listValue' default='aDefaultValue'}}"));
 
-                getAndAssertOk("list/all", contextValue)
-                    .body("$", hasSize(3))
-                    .body("[0].valueOne", equalTo(contextValue))
-                    .body("[0].valueTwo", equalTo("one"))
-                    .body("[1].valueOne", equalTo(contextValue))
-                    .body("[1].valueTwo", equalTo("two"))
-                    .body("[2].valueOne", equalTo(contextValue))
-                    .body("[2].valueTwo", equalTo("three"));
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listValue", "aDefaultValue"));
+            }
+        }
+
+        @DisplayName("when accessing index element")
+        @Nested
+        public class IndexElement {
+
+            @DisplayName("when no default is specified returns empty string")
+            @Test
+            void test_hasDefaultEmptyString() {
+                createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[1].listValue'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listValue", ""));
+            }
+
+            @DisplayName("when default is specified returns default")
+            @Test
+            void test_usesDefault() {
+                createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] property='[1].listValue' default='aDefaultValue'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listValue", "aDefaultValue"));
+            }
+        }
+
+        @DisplayName("when accessing last element")
+        @Nested
+        public class LastElement {
+
+            @DisplayName("when no default is specified returns empty string")
+            @Test
+            void test_hasDefaultEmptyString() {
+                createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[-1].listValue'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listValue", ""));
+            }
+
+            @DisplayName("when default is specified returns default")
+            @Test
+            void test_usesDefault() {
+                createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] property='[-1].listValue' default='aDefaultValue'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listValue", "aDefaultValue"));
+            }
+        }
+
+        @DisplayName("when accessing list property")
+        @Nested
+        public class FullList {
+            @DisplayName("interprets empty default")
+            @Test
+            void test_listEmptyDefault() {
+                createContextGetStubWithBodyFile("list_with_empty_default.json");
+
+                getContextList(contextName, (result) -> assertThat(result).isEmpty());
+            }
+
+            @DisplayName("ignores filled default and takes empty list")
+            @Test
+            void test_listFilledDefault() {
+                createContextGetStubWithBodyFile("list_with_filled_default.json");
+
+                getContextList(contextName, (result) -> assertThat(result).isEmpty());
+            }
+
+            @DisplayName("has proper built-in default")
+            @Test
+            void test_listNoDefault() {
+                createContextGetStubWithBodyFile("list_with_no_default.json");
+
+                getContextList(contextName, (result) -> assertThat(result).isEmpty());
+            }
+        }
+    }
+
+    @DisplayName("with meta properties")
+    @Nested
+    public class MetaProperties {
+
+        @DisplayName("when a context is present")
+        @Nested
+        public class Present {
+
+        }
+
+        @DisplayName("when a context is not present")
+        @Nested
+        public class NotPresent {
+
+            private final String contextName = "unknownContext";
+
+            @DisplayName("uses built-in default for updateCount")
+            @Test
+            public void test_updateCountNoDefault() {
+                createContextGetStub(Map.of("updateCount", "{{state context=request.pathSegments.[1] property='updateCount'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("updateCount", "0"));
+            }
+
+            @DisplayName("uses specified default for updateCount when configured")
+            @Test
+            public void test_updateCountWithDefault() {
+                createContextGetStub(Map.of("updateCount", "{{state context=request.pathSegments.[1] property='updateCount' default='5'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("updateCount", "5"));
+            }
+
+            @DisplayName("uses built-in default for listSize")
+            @Test
+            public void test_ListSizeNoDefault() {
+                createContextGetStub(Map.of("listSize", "{{state context=request.pathSegments.[1] property='listSize'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listSize", "0"));
+            }
+
+            @DisplayName("uses specified default for listSize when configured")
+            @Test
+            public void test_listSizeWithDefault() {
+                createContextGetStub(Map.of("listSize", "{{state context=request.pathSegments.[1] property='listSize' default='5'}}"));
+
+                getContext(contextName, (result) -> assertThat(result).containsEntry("listSize", "5"));
+            }
+        }
+    }
+
+    @DisplayName("with existing property")
+    @Nested
+    public class ExistingProperty {
+
+        private final String contextName = "aContextName";
+
+        @DisplayName("returns property from previous request")
+        @Test
+        void test_returnsState() {
+            Map<String, Object> request = Map.of("contextValue", "aContextValue");
+            createContextStatePostStub(Map.of("contextValue", "{{jsonPath request.body '$.contextValue'}}"));
+            createContextGetStub(Map.of("contextValue", "{{state context=request.pathSegments.[1] property='contextValue'}}"));
+
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsExactlyEntriesOf(request));
+        }
+
+        @DisplayName("with default specified returns property from previous request")
+        @Test
+        void test_withDefaultReturnsState() {
+            Map<String, Object> request = Map.of("contextValue", "aContextValue");
+            createContextStatePostStub(Map.of("contextValue", "{{jsonPath request.body '$.contextValue' default='defaultValue'}}"));
+            createContextGetStub(Map.of("contextValue", "{{state context=request.pathSegments.[1] property='contextValue'}}"));
+
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsExactlyEntriesOf(request));
+        }
+
+        @DisplayName("with multiple properties returns all specified")
+        @Test
+        void test_returnsMultipleStates() {
+            Map<String, Object> request = Map.of("contextValueOne", "aContextValueOne", "contextValueTwo", "aContextValueTwo");
+            createContextStatePostStub(Map.of(
+                "contextValueOne", "{{jsonPath request.body '$.contextValueOne'}}",
+                "contextValueTwo", "{{jsonPath request.body '$.contextValueTwo'}}"
+            ));
+            createContextGetStub(Map.of(
+                "contextValueOne", "{{state context=request.pathSegments.[1] property='contextValueOne'}}",
+                "contextValueTwo", "{{state context=request.pathSegments.[1] property='contextValueTwo'}}"
+            ));
+
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+        }
+
+        @DisplayName("supports returning complete body")
+        @Test
+        void test_returnsCompleteBody() {
+            Map<String, Object> request = Map.of("contextValue", "aContextValue", "nested", Map.of("a", "b"));
+            createContextStatePostStub(Map.of("stateBody", "{{{jsonPath request.body '$'}}}"));
+            createContextGetStub("{{{state context=request.pathSegments.[1] property='stateBody'}}}");
+
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+
+        }
+
+        @DisplayName("with multiple contexts returns correct state")
+        @Test
+        void test_returnsCorrectContext() {
+            Map<String, Object> requestContextOne = Map.of("contextValue", "aContextValueOne");
+            Map<String, Object> requestContextTwo = Map.of("contextValue", "aContextValueTwo");
+            createContextStatePostStub(Map.of("contextValue", "{{jsonPath request.body '$.contextValue'}}"));
+            createContextGetStub(Map.of("contextValue", "{{state context=request.pathSegments.[1] property='contextValue'}}"));
+
+            postContext(contextName + "One", requestContextOne);
+            postContext(contextName + "Two", requestContextTwo);
+            getContext(contextName + "One", (result) -> assertThat(result).containsExactlyEntriesOf(requestContextOne));
+            getContext(contextName + "Two", (result) -> assertThat(result).containsExactlyEntriesOf(requestContextTwo));
+        }
+    }
+
+    @DisplayName("with existing list")
+    @Nested
+    public class ExistingList {
+
+        private final String contextName = "aContextName";
+
+        @DisplayName("with single list element returns first element")
+        @Test
+        void test_singleEntryReturnsFirstElement() {
+            Map<String, Object> request = Map.of("listValue", "aListValue");
+            createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+            createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[0].listValue'}}"));
+
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+        }
+
+        @DisplayName("with default on list value list element returns correct value")
+        @Test
+        void test_withDefaultSingleEntryReturnsFirstElement() {
+            Map<String, Object> request = Map.of("listValue", "aListValue");
+            createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+            createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[0].listValue' default='aDefaultValue'}}"));
+
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+        }
+
+        @DisplayName("with single list element returns last element")
+        @Test
+        void test_singleEntryReturnsLastElement() {
+            Map<String, Object> request = Map.of("listValue", "aListValue");
+            createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+            createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[-1].listValue'}}"));
+
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+        }
+
+        @DisplayName("with multiple list elements returns first element")
+        @Test
+        void test_multipleEntriesReturnsFirstElement() {
+            Map<String, Object> request = Map.of("listValue", "aListValue1");
+            createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+            createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[0].listValue'}}"));
+
+            postContext(contextName, request);
+            postContext(contextName, Map.of("listValue", "aListValue2"));
+            postContext(contextName, Map.of("listValue", "aListValue3"));
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+        }
+
+        @DisplayName("with multiple list elements returns last element")
+        @Test
+        void test_multipleEntriesReturnsLastElement() {
+            Map<String, Object> request = Map.of("listValue", "aListValue3");
+            createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+            createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[-1].listValue'}}"));
+
+            postContext(contextName, Map.of("listValue", "aListValue1"));
+            postContext(contextName, Map.of("listValue", "aListValue2"));
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+        }
+
+        @DisplayName("with multiple list elements returns index element")
+        @Test
+        void test_multipleEntriesReturnsIndexElement() {
+            Map<String, Object> request = Map.of("listValue", "aListValue2");
+            createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+            createContextGetStub(Map.of("listValue", "{{state context=request.pathSegments.[1] list='[1].listValue'}}"));
+
+            postContext(contextName, Map.of("listValue", "aListValue1"));
+            postContext(contextName, request);
+            postContext(contextName, Map.of("listValue", "aListValue3"));
+            getContext(contextName, (result) -> assertThat(result).containsAllEntriesOf(request));
+        }
+
+        @DisplayName("when accessing full list")
+        @Nested
+        public class FullList {
+
+            @DisplayName("with no default renders list with one element")
+            @Test
+            void test_oneElementNoDefault() {
+                Map<String, Object> request = Map.of("listValue", "aListValue");
+                createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+                createContextGetStubWithBodyFile("list_with_no_default.json");
+
+                postContext(contextName, request);
+
+                getContextList(contextName, (result) -> assertThat(result).containsExactly(request));
+            }
+
+            @DisplayName("with default renders list with one element")
+            @Test
+            void test_oneElementWithDefault() {
+                Map<String, Object> request = Map.of("listValue", "aListValue");
+                createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+                createContextGetStubWithBodyFile("list_with_filled_default.json");
+
+                postContext(contextName, request);
+
+                getContextList(contextName, (result) -> assertThat(result).containsExactly(request));
+            }
+
+            @DisplayName("renders list with multiple element")
+            @Test
+            void test_multipleElements() {
+                Map<String, Object> requestOne = Map.of("listValue", "listValueOne");
+                Map<String, Object> requestTwo = Map.of("listValue", "listValueTwo");
+                Map<String, Object> requestThree = Map.of("listValue", "listValueThree");
+                createContextListPostStub(Map.of("listValue", "{{jsonPath request.body '$.listValue'}}"));
+                createContextGetStubWithBodyFile("list_with_no_default.json");
+
+                postContext(contextName, requestOne);
+                postContext(contextName, requestTwo);
+                postContext(contextName, requestThree);
+
+                getContextList(contextName, (result) -> assertThat(result).containsExactly(requestOne, requestTwo, requestThree));
             }
         }
     }

--- a/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/list_with_empty_default.json
+++ b/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/list_with_empty_default.json
@@ -1,0 +1,7 @@
+[
+{{#each (state context=request.pathSegments.[1] property='list' default='[]') }}
+  {
+    "listValue": "{{listValue}}"
+  }{{#unless @last}},{{/unless}}
+{{/each}}
+]

--- a/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/list_with_filled_default.json
+++ b/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/list_with_filled_default.json
@@ -1,0 +1,7 @@
+[
+{{#each (state context=request.pathSegments.[1] property='list' default='[{"listValue": "defaultListValue"}]') }}
+  {
+    "listValue": "{{listValue}}"
+  }{{#unless @last}},{{/unless}}
+{{/each}}
+]

--- a/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/list_with_no_default.json
+++ b/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/list_with_no_default.json
@@ -1,0 +1,7 @@
+[
+{{#each (state context=request.pathSegments.[1] property='list') }}
+  {
+    "listValue": "{{listValue}}"
+  }{{#unless @last}},{{/unless}}
+{{/each}}
+]

--- a/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/test_knownProperties_usesDefaultOrNull.post.json
+++ b/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/test_knownProperties_usesDefaultOrNull.post.json
@@ -1,0 +1,10 @@
+{
+  "valueOne": "{{state context=request.pathSegments.[1] property='stateValueOne'}}",
+  "valueTwo": {{#with (state context=request.pathSegments.[1] property='stateValueTwo') as | value |}}"{{value}}"{{else}}null{{/with}},
+  {{#with (state context=request.pathSegments.[1] property='stateValueTwo') as | value |}}
+    "valueTwoRemovedWhenNotNull": "{{value}}",
+  {{else}}{{/with}}
+  "listSize": "{{state context=request.pathSegments.[1] property='listSize'}}",
+  "valueTwoWithDefault": "{{state context=request.pathSegments.[1] property='stateValueTwo' default='valueTwoDefault'}}",
+  "unknown": "{{state context=request.pathSegments.[1] property='unknown' default='defaultUnknown'}}"
+}

--- a/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/test_unknownProperties_usesDefaultOrNull.post.json
+++ b/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/test_unknownProperties_usesDefaultOrNull.post.json
@@ -1,0 +1,9 @@
+{
+  "valueOne": "{{state context=request.pathSegments.[1] property='unknownValue'}}",
+  "valueTwo": {{#with (state context=request.pathSegments.[1] property='unknownValue') as | value |}}"{{value}}"{{else}}null{{/with}},
+  {{#with (state context=request.pathSegments.[1] property='unknownValue') as | value |}}
+    "valueTwoRemovedWhenNotNull": "{{value}}",
+  {{else}}{{/with}}
+  "valueTwoWithDefault": "{{state context=request.pathSegments.[1] property='unknownValue' default='valueTwoDefault'}}",
+  "unknown": "{{state context=request.pathSegments.[1] property='unknown' default='defaultUnknown'}}"
+}

--- a/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/value_or_ignore.json
+++ b/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/value_or_ignore.json
@@ -1,0 +1,5 @@
+{
+  {{#with (state context=request.pathSegments.[1] property='contextValue') as | value |}}
+  "contextValue": "{{value}}"
+  {{else}}{{/with}}
+}

--- a/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/value_or_null.json
+++ b/src/test/resources/__files/StateTemplateHelperProviderExtensionTest/value_or_null.json
@@ -1,0 +1,3 @@
+{
+  "contextValue": {{#with (state context=request.pathSegments.[1] property='contextValue') as | value |}}"{{value}}"{{else}}null{{/with}}
+}


### PR DESCRIPTION
- use proper defaults (most times an empty string)
  - this is BREAKING as previously, errors where printed in the JSON
- restructure `StateTemplateHelperProviderExtensionTest` to ease test interpretation
- added more logging for these cases
- added documentation

<!-- Please describe your pull request here. -->

## References

#67 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
