### PR TITLE
Maven central release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,21 @@ jobs:
           distribution: 'adopt'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
+
+      - name: Determine new version
+        id: new_version
+        run: |
+          NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
+          echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Publish package
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publish
+          arguments: -Pversion=${{ steps.new_version.outputs.new_version }} publish
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          OSSRH_GPG_SECRET_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          OSSRH_GPG_SECRET_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.22.0'
     id 'com.palantir.git-version' version '3.0.0'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'io.github.gradle-nexus.publish-plugin' version "1.0.0"
 }
 
 wrapper {
@@ -37,6 +38,11 @@ project.ext {
 project.archivesBaseName = "${baseArtifact}"
 configurations {
     standaloneOnly
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
 }
 
 jar {
@@ -71,9 +77,27 @@ shadowJar {
     exclude 'handlebars-*.js'
 }
 
-group 'org.wiremock'
+group 'org.wiremock.extensions'
 
 version gitVersion()
+
+signing {
+    // Docs: https://github.com/wiremock/community/blob/main/infra/maven-central.md
+    required {
+        !version.toString().contains("SNAPSHOT") && (gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish"))
+    }
+    def signingKey = providers
+        .environmentVariable("OSSRH_GPG_SECRET_KEY")
+        .forUseAtConfigurationTime()
+    def signingPassphrase = providers
+        .environmentVariable("OSSRH_GPG_SECRET_KEY_PASSWORD")
+        .forUseAtConfigurationTime()
+    if (signingKey.present && signingPassphrase.present) {
+        useInMemoryPgpKeys(signingKey.get(), signingPassphrase.get())
+        def extension = extensions.getByName("publishing") as PublishingExtension
+        sign(extension.publications)
+    }
+}
 
 publishing {
     repositories {
@@ -213,3 +237,23 @@ idea {
     }
 }
 
+nexusPublishing {
+    // See https://github.com/wiremock/community/blob/main/infra/maven-central.md
+    repositories {
+        sonatype {
+            nexusUrl = uri("https://oss.sonatype.org/service/local/")
+            snapshotRepositoryUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+
+            def ossrhUsername = providers
+                    .environmentVariable("OSSRH_USERNAME")
+                    .forUseAtConfigurationTime()
+            def ossrhPassword = providers
+                    .environmentVariable("OSSRH_TOKEN")
+                    .forUseAtConfigurationTime()
+            if (ossrhUsername.present && ossrhPassword.present) {
+                username = ossrhUsername.get()
+                password = ossrhPassword.get()
+            }
+        }
+    }
+}


### PR DESCRIPTION
For #71 . It is unlikely we will get it working in a single PR though 

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
