### PR TITLE
Escape @ in Javadoc to fix Java 11 builds

### DIFF
--- a/src/main/java/org/wiremock/extensions/state/StateExtension.java
+++ b/src/main/java/org/wiremock/extensions/state/StateExtension.java
@@ -37,14 +37,14 @@ import java.util.List;
  * <pre>{@code
  *     private static final Store<String, Object> store = new CaffeineStore();
  *
- *     @RegisterExtension
+ *     {@literal @}RegisterExtension
  *     public static WireMockExtension wm = WireMockExtension.newInstance()
  *         .options(
  *             wireMockConfig().dynamicPort().dynamicHttpsPort()
  *                 .extensions(new StateExtension(store))
  *         )
  *         .build();
- *         }
+ *      }
  * </pre>
  */
 public class StateExtension implements ExtensionFactory {


### PR DESCRIPTION
For #73 

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
