### PR TITLE
Add quick access badges to the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # WireMock State extension
 
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/wiremock/wiremock-extension-state)](https://github.com/wiremock/wiremock-extension-state/releases)
+[![Slack](https://img.shields.io/badge/slack-slack.wiremock.org-brightgreen?style=flat&logo=slack)](https://slack.wiremock.org/)
+[![GitHub contributors](https://img.shields.io/github/contributors/wiremock/wiremock-extension-state)](https://github.com/wiremock/wiremock-extension-state/graphs/contributors)
+
 <p align="center">
     <a href="https://wiremock.org" target="_blank">
         <img width="512px" src="https://wiremock.org/images/logos/wiremock/logo_wide.svg" alt="WireMock Logo"/>


### PR DESCRIPTION
Mostly to trigger another release...

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
