### PR TITLE
Rename repository to wiremock-state-extension

### DIFF
--- a/.run/WireMock Docker Demo.run.xml
+++ b/.run/WireMock Docker Demo.run.xml
@@ -4,7 +4,7 @@
       <settings>
         <option name="imageTag" value="wiremock/wiremock:3x" />
         <option name="command" value="--global-response-templating --jetty-header-request-size 32768 --jetty-header-response-size 32768 --verbose" />
-        <option name="containerName" value="wiremock-extension-state-test" />
+        <option name="containerName" value="wiremock-state-extension-test" />
         <option name="portBindings">
           <list>
             <DockerPortBindingImpl>

--- a/.run/WireMock Docker Test.run.xml
+++ b/.run/WireMock Docker Test.run.xml
@@ -4,7 +4,7 @@
       <settings>
         <option name="imageTag" value="wiremock/wiremock:3x" />
         <option name="command" value="--global-response-templating --verbose" />
-        <option name="containerName" value="wiremock-extension-state-test" />
+        <option name="containerName" value="wiremock-state-extension-test" />
         <option name="portBindings">
           <list>
             <DockerPortBindingImpl>

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ wiremock/wiremock:3x \
 
 ## Releasing
 
-To release the module, go to [GitHub Releases](https://github.com/wiremock/wiremock-extension-state/releases) and
+To release the module, go to [GitHub Releases](https://github.com/wiremock/wiremock-state-extension/releases) and
 issue the release using the changelog draft.
-The new release will trigger the [Release GitHub Action](https://github.com/wiremock/wiremock-extension-state/actions/workflows/release.yml)
+The new release will trigger the [Release GitHub Action](https://github.com/wiremock/wiremock-state-extension/actions/workflows/release.yml)
 which will deploy the artifacts to Maven Central.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # WireMock State extension
 
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/wiremock/wiremock-extension-state)](https://github.com/wiremock/wiremock-extension-state/releases)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/wiremock/wiremock-state-extension)](https://github.com/wiremock/wiremock-state-extension/releases)
 [![Slack](https://img.shields.io/badge/slack-slack.wiremock.org-brightgreen?style=flat&logo=slack)](https://slack.wiremock.org/)
-[![GitHub contributors](https://img.shields.io/github/contributors/wiremock/wiremock-extension-state)](https://github.com/wiremock/wiremock-extension-state/graphs/contributors)
+[![GitHub contributors](https://img.shields.io/github/contributors/wiremock/wiremock-state-extension)](https://github.com/wiremock/wiremock-state-extension/graphs/contributors)
 
 <p align="center">
     <a href="https://wiremock.org" target="_blank">
@@ -172,7 +172,7 @@ the `GET` won't have any knowledge of the previous post.
 
 ## Compatibility matrix
 
-| `wiremock-extension-state` version | `WireMock` version |
+| `wiremock-state-extension` version | `WireMock` version |
 |------------------------------------|--------------------|
 | `0.0.3`+                           | `3.0.0-beta-11`+   |
 | `0.0.6`+                           | `3.0.0-beta-14`+   |

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ add authentication to GitHub packages.
 
 <repositories>
     <repository>
-        <id>github-wiremock-extension-state</id>
+        <id>github-wiremock-state-extension</id>
         <name>WireMock Extension State Apache Maven Packages</name>
-        <url>https://maven.pkg.github.com/wiremock/wiremock-extension-state</url>
+        <url>https://maven.pkg.github.com/wiremock/wiremock-state-extension</url>
     </repository>
 </repositories>
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/wiremock/wiremock-extension-state"
+            url = "https://maven.pkg.github.com/wiremock/wiremock-state-extension"
             credentials {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")
@@ -121,13 +121,13 @@ publishing {
             pom {
                 name = "${baseArtifact}"
                 description = 'A WireMock extension to transfer state in between stubs'
-                url = 'https://github.com/dirkbolte/wiremock-extension-state'
+                url = 'https://github.com/wiremock/wiremock-state-extension'
 
 
                 scm {
-                    connection = 'https://github.com/dirkbolte/wiremock-extension-state.git'
-                    developerConnection = 'https://github.com/dirkbolte/wiremock-extension-state.git'
-                    url = 'https://github.com/dirkbolte/wiremock-extension-state.git'
+                    connection = 'https://github.com/wiremock/wiremock-state-extension.git'
+                    developerConnection = 'https://github.com/wiremock/wiremock-state-extension.git'
+                    url = 'https://github.com/wiremock/wiremock-state-extension.git'
                 }
 
                 licenses {
@@ -156,13 +156,13 @@ publishing {
 
                 name = "${baseArtifact}-standalone"
                 description = 'A WireMock extension to transfer state in between stubs - to be used with WireMock standalone'
-                url = 'https://github.com/dirkbolte/wiremock-extension-state'
+                url = 'https://github.com/wiremock/wiremock-state-extension'
 
 
                 scm {
-                    connection = 'https://github.com/dirkbolte/wiremock-extension-state.git'
-                    developerConnection = 'https://github.com/dirkbolte/wiremock-extension-state.git'
-                    url = 'https://github.com/dirkbolte/wiremock-extension-state.git'
+                    connection = 'https://github.com/wiremock/wiremock-state-extension.git'
+                    developerConnection = 'https://github.com/wiremock/wiremock-state-extension.git'
+                    url = 'https://github.com/wiremock/wiremock-state-extension.git'
                 }
 
                 licenses {
@@ -239,8 +239,12 @@ nexusPublishing {
             // TODO: allow configuring destinations for oss1
             // nexusUrl.set(uri("https://oss.sonatype.org/service/local/"))
             // snapshotRepositoryUrl.set(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
-            username.set(providers.environmentVariable("OSSRH_USERNAME").orElse(null).get())
-            password.set(providers.environmentVariable("OSSRH_TOKEN").orElse(null).get())
+            def envUsername = providers.environmentVariable("OSSRH_USERNAME").orElse(null).get()
+            def envPassword = providers.environmentVariable("OSSRH_TOKEN").orElse(null).get()
+            if (envUsername != null && envPassword != null) {
+                username.set(envUsername)
+                password.set(envPassword)
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -239,9 +239,9 @@ nexusPublishing {
             // TODO: allow configuring destinations for oss1
             // nexusUrl.set(uri("https://oss.sonatype.org/service/local/"))
             // snapshotRepositoryUrl.set(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
-            def envUsername = providers.environmentVariable("OSSRH_USERNAME").orElse(null).get()
-            def envPassword = providers.environmentVariable("OSSRH_TOKEN").orElse(null).get()
-            if (envUsername != null && envPassword != null) {
+            def envUsername = providers.environmentVariable("OSSRH_USERNAME").orElse("").get()
+            def envPassword = providers.environmentVariable("OSSRH_TOKEN").orElse("").get()
+            if (!envUsername.isEmpty() && !envPassword.isEmpty()) {
                 username.set(envUsername)
                 password.set(envPassword)
             }

--- a/demo/README.md
+++ b/demo/README.md
@@ -11,7 +11,7 @@ This is a demonstration of the WireMock State Extension, showcasing its initial 
 ## General Overview
 
 - **Watch the Demo Video**: [WireMock State Extension Demo Video](https://www.youtube.com/watch?v=OUrMEpzHbvY)
-- **View the Slides**: [WireMock State Extension Slides](https://github.com/wiremock/wiremock-extension-state/blob/develop/demo/wiremock_state_extension_webinar.pdf)
+- **View the Slides**: [WireMock State Extension Slides](https://github.com/wiremock/wiremock-state-extension/blob/develop/demo/wiremock_state_extension_webinar.pdf)
 
 ## Initial Feature Set: The State
 
@@ -83,8 +83,8 @@ Before you begin, ensure you have the following prerequisites installed on your 
 ### Step 1: Clone the WireMock State Extension Repository
 
 ```shell
-git clone https://github.com/wiremock/wiremock-extension-state.git
-cd wiremock-extension-state
+git clone https://github.com/wiremock/wiremock-state-extension.git
+cd wiremock-state-extension
 ```
 
 ### Step 2: Build the Project


### PR DESCRIPTION
I changed everything except the #81 scope post-release

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
