### PR TITLE
Workaround Gradle dependency bug for signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,12 @@ publish.dependsOn checkReleasePreconditions
 publish.dependsOn 'signStandaloneJarPublication'
 publish.dependsOn 'signMavenJavaPublication'
 
+// FIXME: remove after https://github.com/gradle/gradle/issues/26091
+tasks.withType(AbstractPublishToMaven).configureEach {
+  def signingTasks = tasks.withType(Sign)
+  mustRunAfter(signingTasks)
+}
+
 repositories {
     mavenCentral()
     mavenLocal()


### PR DESCRIPTION
Well, now we hit https://github.com/gradle/gradle/issues/26091 which is yet to be fixed in Gradle. So I force all-to-all signing dependencies

