### PR TITLE
feat: support built-in WireMock matchers on properties and list entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ the `GET` won't have any knowledge of the previous post.
 |------------------------------------|--------------------|
 | `0.0.3`+                           | `3.0.0-beta-11`+   |
 | `0.0.6`+                           | `3.0.0-beta-14`+   |
-| `0.1.0`+                           | `3.0.0`+   |
+| `0.1.0`+                           | `3.0.0`+           |
 
 ## Installation
 
@@ -308,7 +308,7 @@ wiremock/wiremock:3.3.0 \
 The state is recorded in `serveEventListeners` of a stub. The following functionalities are provided:
 
 - `state` : stores a state in a context. Storing the state multiple times can be used to selectively overwrite existing properties.
-  - to delete a selective property, set it to `null` (as string).
+    - to delete a selective property, set it to `null` (as string).
 - `list` : stores a state in a list. Can be used to prepend/append new states to an existing list. List elements cannot be modified (only read/deleted).
 
 `state` and `list` can be used in the same `ServeEventListener` (would count as two updates). Adding multiple `recordState` `ServeEventListener` is supported.
@@ -702,8 +702,8 @@ to avoid memory leaks).
 The default expiration is 60 minutes. The default value can be overwritten (`0` = default = 60 minutes):
 
 ```java
-int expiration=1024;
-var store=new CaffeineStore(expiration);
+int expiration = 1024;
+var store = new CaffeineStore(expiration);
 ```
 
 ## Match a request against a context
@@ -760,6 +760,46 @@ As for other matchers, templating is supported.
 }
 ```
 
+### Full flexible property match
+
+In case you want full flexibility into matching on a property, you can simply specify `property` and use one of WireMock's built-in matchers, allowing you to
+configure
+logical operators, regex, date matchers, absence and much more. The basic syntax:
+
+```json
+"property": {
+<property-a>: <matcher-a>,
+<property-b>: <matcher-b>
+}
+```
+
+Example:
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/test/[^\/]+/[^\/]+",
+    "customMatcher": {
+      "name": "state-matcher",
+      "parameters": {
+        "property": {
+          "myProperty": {
+            "contains": "myValue"
+          }
+        }
+      }
+    },
+    "response": {
+      "status": 200
+    }
+  }
+```
+
+The implementation makes use of WireMock's internal matching system and supports any implementation of `StringValuePattern`. As of WireMock 3.3, this includes
+`equalTo`,`equalToJson`,`matchesJsonPath`,`matchesJsonSchema`,`equalToXml`,`matchesXPath`,`contains`,`not`,`doesNotContain`,`matches`,`doesNotMatch`,`before`,
+`after`,`equalToDateTime`,`anything`,`absent`,`and`,`or`,`matchesPathTemplate`.
+For documentation on using these matchers, check the [WireMock documentation](https://wiremock.org/docs/request-matching/)
 
 ### Context update count match
 
@@ -770,7 +810,8 @@ for request matching as well. The following matchers are available:
 - `updateCountLessThan`
 - `updateCountMoreThan`
 
-As for other matchers, templating is supported. In case the provided value for this check is not numeric, it is handled as non-matching. No error will be reported or logged.
+As for other matchers, templating is supported. In case the provided value for this check is not numeric, it is handled as non-matching. No error will be
+reported or logged.
 
 ```json
 {
@@ -800,7 +841,8 @@ for request matching as well. The following matchers are available:
 - `listSizeLessThan`
 - `listSizeMoreThan`
 
-As for other matchers, templating is supported. In case the provided value for this check is not numeric, it is handled as non-matching. No error will be reported or logged.
+As for other matchers, templating is supported. In case the provided value for this check is not numeric, it is handled as non-matching. No error will be
+reported or logged.
 
 ```json
 {
@@ -820,6 +862,57 @@ As for other matchers, templating is supported. In case the provided value for t
   }
 }
 ```
+
+### Full flexible list entry property match
+
+Similar to properties, you have full flexibility into matching on a property of a list entry by specifying `list` and using one of WireMock's built-in matchers
+The basic syntax:
+
+```json
+"list": {
+  <index-a>: {
+    <property-a>: <matcher-a>,
+    <property-b>: <matcher-b>
+  },
+  <index-b>: {
+    <property-a>: <matcher-a>,
+    <property-b>: <matcher-b>
+  }
+}
+```
+
+As index, you can use the actual index as well as `first`, `last`, `-1`.
+
+Example:
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/test/[^\/]+/[^\/]+",
+    "customMatcher": {
+      "name": "state-matcher",
+      "parameters": {
+        "list": {
+          "1": {
+            "myProperty": {
+              "contains": "myValue"
+            }
+          }
+        }
+      }
+    },
+    "response": {
+      "status": 200
+    }
+  }
+```
+
+The implementation makes use of WireMock's internal matching system and supports any implementation of `StringValuePattern`. As of WireMock 3.3, this includes
+`equalTo`,`equalToJson`,`matchesJsonPath`,`matchesJsonSchema`,`equalToXml`,`matchesXPath`,`contains`,`not`,`doesNotContain`,`matches`,`doesNotMatch`,`before`,
+`after`,`equalToDateTime`,`anything`,`absent`,`and`,`or`,`matchesPathTemplate`.
+For documentation on using these matchers, check the [WireMock documentation](https://wiremock.org/docs/request-matching/)
+
 
 ### Negative context exists match
 
@@ -931,10 +1024,10 @@ Example with bodyFileName:
 
 ### Missing properties and defaults
 
-Missing Helper properties as well as unknown context properties result in using a built-in default. 
+Missing Helper properties as well as unknown context properties result in using a built-in default.
 
 You can also specify a `default` for the state
-helper: `"clientId": "{{state context=request.pathSegments.[1] property='firstname' default='John'}}",` . 
+helper: `"clientId": "{{state context=request.pathSegments.[1] property='firstname' default='John'}}",` .
 
 If unsure, you may consult the log for to see whether an error occurred.
 
@@ -984,7 +1077,7 @@ and setting `verbose=true` or starting WireMock standalone (or docker) with `ver
 
 - EventListeners and Matchers report errors with WireMock-internal exceptions. Additionally, errors are logged.
   In order to see them, [register a notifier](https://wiremock.org/3.x/docs/configuration/#notification-logging).
-- Response templating errors are printed in the actual response body. 
+- Response templating errors are printed in the actual response body.
 - Various actions and decisions of this extensions are logged on info level, along with the context they are happening in.
 
 # Examples

--- a/src/test/java/org/wiremock/extensions/state/functionality/RecordStateEventListenerTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/RecordStateEventListenerTest.java
@@ -18,9 +18,12 @@ package org.wiremock.extensions.state.functionality;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import io.restassured.http.ContentType;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -320,5 +323,11 @@ class RecordStateEventListenerTest extends AbstractTestBase {
             assertContextNumUpdates(contextTwo, 1);
         }
 
+        @Disabled
+        @DisplayName("update count only increased by one when both property and list are updated")
+        @Test
+        void test_updatePropertyAndList_incOne() {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
@@ -15,8 +15,9 @@
  */
 package org.wiremock.extensions.state.functionality;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
@@ -24,123 +25,56 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.common.Pair.pair;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class StateRequestMatcherTest extends AbstractTestBase {
 
     private static final String TEST_URL = "/test";
 
-    @BeforeEach
-    void setup() throws JsonProcessingException {
-        createPostStub();
-        createGetStubs();
-        createDeleteStub();
+    private void createGetStub(String check, Object configuration) {
+        createGetStub(Map.of(
+            "hasContext", "{{request.pathSegments.[2]}}",
+            check, configuration
+        ));
     }
 
-    private void createDeleteStub() {
+    private void createGetStub(Map<String, Object> configuration) {
         wm.stubFor(
-            delete(urlPathMatching(TEST_URL + "/all/[^/]+"))
-                .andMatching("state-matcher", Parameters.one("hasContext", "{{request.pathSegments.[2]}}"))
+            get(urlPathMatching(TEST_URL + "/check/[^/]+"))
+                .andMatching("state-matcher", Parameters.from(configuration))
                 .willReturn(WireMock.ok())
-                .withServeEventListener(
-                    "deleteState",
-                    Parameters.from(
-                        Map.of(
-                            "context", "{{jsonPath response.body '$.id'}}",
-                            "list", Map.of("deleteFirst", true)
-                        )
-                    )
-                )
         );
     }
 
-    private void createGetStubs() throws JsonProcessingException {
-        wm.stubFor(
-            get(urlPathMatching(TEST_URL + "/all/[^/]+"))
-                .andMatching("state-matcher", Parameters.one("hasContext", "{{request.pathSegments.[2]}}"))
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            mapper.readTree(
-                                mapper.writeValueAsString(Map.of(
-                                    "status", "context found",
-                                    "updateCount", "{{state context=request.pathSegments.[2] property='updateCount'}}",
-                                    "listSize", "{{state context=request.pathSegments.[2] property='listSize'}}"
-                                )))
-                        )
-                )
-        );
-        wm.stubFor(
-            get(urlPathMatching(TEST_URL + "/all/[^/]+"))
-                .andMatching("state-matcher", Parameters.one("hasNotContext", "{{request.pathSegments.[2]}}"))
-                .willReturn(
-                    WireMock.notFound()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            mapper.readTree(
-                                mapper.writeValueAsString(Map.of("status", "context not found")))
-                        )
-                )
-        );
-        createGetStubs("hasProperty");
-        createGetStubs("hasNotProperty");
-        createGetStubs("updateCountEqualTo");
-        createGetStubs("updateCountLessThan");
-        createGetStubs("updateCountMoreThan");
-        createGetStubs("listSizeEqualTo");
-        createGetStubs("listSizeLessThan");
-        createGetStubs("listSizeMoreThan");
-    }
-
-    private void createGetStubs(String check) throws JsonProcessingException {
-        wm.stubFor(
-            get(urlPathMatching(TEST_URL + "/" + check + "/[^/]+/[^/]+"))
-                .andMatching("state-matcher", Parameters.from(
-                    Map.of(
-                        "hasContext", "{{request.pathSegments.[3]}}",
-                        check, "{{request.pathSegments.[2]}}"
-                    ))
-                )
-                .willReturn(
-                    WireMock.ok()
-                        .withHeader("content-type", "application/json")
-                        .withJsonBody(
-                            mapper.readTree(
-                                mapper.writeValueAsString(Map.of(
-                                    "status", "context found",
-                                    "updateCount", "{{state context=request.pathSegments.[3] property='updateCount'}}",
-                                    "listSize", "{{state context=request.pathSegments.[3] property='listSize'}}"
-                                )))
-                        )
-                )
-        );
-    }
-
-    private void createPostStub() throws JsonProcessingException {
+    private void createPostStub() {
         wm.stubFor(
             post(urlEqualTo(TEST_URL))
                 .willReturn(
                     WireMock.ok()
                         .withHeader("content-type", "application/json")
                         .withJsonBody(
-                            mapper.readTree(
-                                mapper.writeValueAsString(Map.of("id", "{{randomValue length=32 type='ALPHANUMERIC' uppercase=false}}")))
+                            Json.node(
+                                Json.write(Map.of("id", "{{randomValue length=32 type='ALPHANUMERIC' uppercase=false}}"))
+                            )
                         )
                 )
                 .withServeEventListener(
@@ -187,24 +121,13 @@ class StateRequestMatcherTest extends AbstractTestBase {
         );
     }
 
-    private ValidatableResponse getAndAssertContextMatcher(String context, String path, int httpStatus, String statusValue) {
-        return getAndAssertContextMatcher(context, path, httpStatus)
-            .body("status", equalTo(statusValue));
-    }
-
-    private ValidatableResponse getAndAssertContextMatcher(String context, String path, int httpStatus) {
+    private ValidatableResponse getAndAssertContextMatcher(String context, int httpStatus) {
         return given()
             .accept(ContentType.JSON)
             .accept(ContentType.TEXT)
-            .get(assertDoesNotThrow(() -> new URI(String.format("%s%s/%s/%s", wm.getRuntimeInfo().getHttpBaseUrl(), TEST_URL, path, context))))
+            .get(assertDoesNotThrow(() -> new URI(String.format("%s%s/check/%s", wm.getRuntimeInfo().getHttpBaseUrl(), TEST_URL, context))))
             .then()
             .statusCode(httpStatus);
-    }
-
-    private void getAndAssertContextMatcher(String context, String path, int httpStatus, String statusValue, String updateCount, String listSize) {
-        getAndAssertContextMatcher(context, path, httpStatus, statusValue)
-            .body("updateCount", equalTo(updateCount))
-            .body("listSize", equalTo(listSize));
     }
 
     private String postAndAssertContextValue(String contextValue) {
@@ -248,232 +171,551 @@ class StateRequestMatcherTest extends AbstractTestBase {
         return context;
     }
 
+    @DisplayName("with matcher 'hasNotContext'")
     @Nested
     public class HasNotContext {
+        private final String contextValue = RandomStringUtils.randomAlphabetic(5);
+
+        @BeforeEach
+        public void setup() {
+            wm.resetAll();
+            createPostStub();
+        }
+
+        @DisplayName("succeeds when the context does not exist")
         @Test
-        void test_unknownContext_notFound() {
-            String context = RandomStringUtils.randomAlphabetic(5);
-            getAndAssertContextMatcher(context, "all", HttpStatus.SC_NOT_FOUND, "context not found");
+        void test_findsContext_doesNotExist_ok() {
+            createGetStub(Map.of("hasNotContext", "unknownContext"));
+
+            getAndAssertContextMatcher("unknownContext", HttpStatus.SC_OK);
+        }
+
+        @DisplayName("fails when the context exists")
+        @Test
+        void test_findsContext_exist_fail() {
+            var context = postAndAssertContextValue(contextValue);
+            createGetStub(Map.of("hasNotContext", context));
+
+            getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+        }
+
+        @DisplayName("with other contexts available")
+        @Nested
+        public class WithOtherContexts {
+
+            @BeforeEach
+            public void setup() {
+                postAndAssertContextValue(RandomStringUtils.randomAlphabetic(5));
+                postAndAssertContextValue(RandomStringUtils.randomAlphabetic(5));
+            }
+
+            @DisplayName("succeeds when the context does not exist")
+            @Test
+            void test_findsContext_doesNotExist_ok() {
+                createGetStub(Map.of("hasNotContext", "unknownContext"));
+
+                getAndAssertContextMatcher("unknownContext", HttpStatus.SC_OK);
+            }
+
+            @DisplayName("succeeds when the context exists")
+            @Test
+            void test_findsContext_exist_fail() {
+                var context = postAndAssertContextValue(contextValue);
+                createGetStub(Map.of("hasNotContext", context));
+
+                getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+            }
         }
     }
 
+    @DisplayName("with matcher 'hasContext'")
     @Nested
     public class hasContext {
+        private final String contextValue = RandomStringUtils.randomAlphabetic(5);
 
+        @BeforeEach
+        public void setup() {
+            wm.resetAll();
+            createPostStub();
+        }
+
+        @DisplayName("fails when the context does not exist")
         @Test
-        void test_findsContext_ok() {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
+        void test_findsContext_doesNotExist_fail() {
+            createGetStub(Map.of("hasContext", "unknownContext"));
 
+            getAndAssertContextMatcher("unknownContext", HttpStatus.SC_NOT_FOUND);
+        }
+
+        @DisplayName("succeeds when the context exists")
+        @Test
+        void test_findsContext_exist_ok() {
             var context = postAndAssertContextValue(contextValue);
-            getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
+            createGetStub(Map.of("hasContext", context));
+
+            getAndAssertContextMatcher(context, HttpStatus.SC_OK);
         }
 
-        @Test
-        void test_unknownContextWithOtherContextAvailable_notFound() {
-            var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-            var context = postAndAssertContextValue(contextValue);
-            getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
-            getAndAssertContextMatcher(RandomStringUtils.randomAlphabetic(5), "all", HttpStatus.SC_NOT_FOUND, "context not found");
-        }
-
-        @Test
-        void test_multipleContexts_ok() {
-            var contextValueOne = RandomStringUtils.randomAlphabetic(5);
-            var contextValueTwo = RandomStringUtils.randomAlphabetic(5);
-
-            var contextOne = postAndAssertContextValue(contextValueOne);
-            var contextTwo = postAndAssertContextValue(contextValueTwo);
-
-            getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "2", "1");
-            getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
-        }
-
+        @DisplayName("with other contexts available")
         @Nested
-        public class Property {
+        public class WithOtherContexts {
+
+            @BeforeEach
+            public void setup() {
+                postAndAssertContextValue(RandomStringUtils.randomAlphabetic(5));
+                postAndAssertContextValue(RandomStringUtils.randomAlphabetic(5));
+            }
+
+            @DisplayName("fails when the context does not exist")
+            @Test
+            void test_findsContext_doesNotExist_fail() {
+                createGetStub(Map.of("hasContext", "unknownContext"));
+
+                getAndAssertContextMatcher("unknownContext", HttpStatus.SC_NOT_FOUND);
+            }
+
+            @DisplayName("succeeds when the context exists")
+            @Test
+            void test_findsContext_exist_ok() {
+                var context = postAndAssertContextValue(contextValue);
+                createGetStub(Map.of("hasContext", context));
+
+                getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+            }
+        }
+
+        @DisplayName("with matcher 'hasProperty'")
+        @Nested
+        public class HasProperty {
+            private final String contextValue = RandomStringUtils.randomAlphabetic(5);
+            private String context;
+
+            @BeforeEach
+            void setup() {
+                createPostStub();
+                context = postAndAssertContextValue(contextValue);
+            }
+
+            @DisplayName("fails when the property does not exist")
             @Test
             void test_hasProperty_propertyDoesNotExist_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+                createGetStub("hasProperty", "unknownValue");
 
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "hasProperty/unknownValue", HttpStatus.SC_NOT_FOUND);
+                getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
             }
 
+            @DisplayName("succeeds when the property exists")
             @Test
             void test_hasProperty_propertyExists_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+                createGetStub("hasProperty", "stateValue");
 
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "hasProperty/stateValue", HttpStatus.SC_OK, "context found", "2", "1");
+                getAndAssertContextMatcher(context, HttpStatus.SC_OK);
             }
 
+            @DisplayName("fails when the property got deleted")
             @Test
             void test_hasProperty_propertyGotDeleted_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                postAndAssertContextValue(contextValue);
+                createGetStub("hasProperty", "stateValue");
                 postAndAssertContextValue(context, null);
-                getAndAssertContextMatcher(context, "hasProperty/stateValue", HttpStatus.SC_NOT_FOUND);
-            }
 
-            @Test
-            void test_hasNotProperty_propertyExists_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "hasNotProperty/stateValue", HttpStatus.SC_NOT_FOUND);
-
-            }
-
-            @Test
-            void test_hasNotProperty_propertyDoesNotExists_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "hasNotProperty/unknownValue", HttpStatus.SC_OK, "context found", "2", "1");
-
+                getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
             }
         }
 
+        @DisplayName("with matcher 'hasNotProperty'")
+        @Nested
+        public class HasNotProperty {
+            private final String contextValue = RandomStringUtils.randomAlphabetic(5);
+            private String context;
+
+            @BeforeEach
+            void setup() {
+                createPostStub();
+                context = postAndAssertContextValue(contextValue);
+            }
+
+            @DisplayName("fails when the property exists")
+            @Test
+            void test_propertyExists_fail() {
+                createGetStub("hasNotProperty", "stateValue");
+
+                getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+            }
+
+            @DisplayName("succeeds when the property does not exist")
+            @Test
+            void test_propertyDoesNotExists_ok() {
+                createGetStub("hasNotProperty", "unknownValue");
+
+                getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+            }
+        }
+
+        @DisplayName("with matcher 'property'")
+        @Nested
+        public class PropertyMatcher {
+            private final String contextValue = "abcdefghijklmn";
+            private String context;
+
+            @BeforeEach
+            void setup() {
+                createPostStub();
+                context = postAndAssertContextValue(contextValue);
+            }
+
+            @DisplayName("fails on invalid built-in matchers")
+            @Test
+            void test_evaluateBuiltinMatchers_fail() {
+                createGetStub("property", Map.of("stateValue", Map.of("contains", Map.of("invalid", "invalid"))));
+                getAndAssertContextMatcher(context, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            }
+
+            @DisplayName("can evaluate built-in matchers")
+            @Test
+            void test_evaluateBuiltinMatchers_ok() {
+                createGetStub("property", Map.of("stateValue", Map.of("contains", "defg")));
+                getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+            }
+
+            @DisplayName("fails on unmatched built-in matchers")
+            @Test
+            void test_failingBuiltinMatchers_fail() {
+                createGetStub("property", Map.of("stateValue", Map.of("contains", "11111")));
+                getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+            }
+
+            @DisplayName("can evaluate nested built-in matchers")
+            @Test
+            void test_evaluateNestedBuiltinMatchers_ok() {
+                createGetStub("property",
+                    Map.of(
+                        "stateValue",
+                        Map.of("or",
+                            List.of(
+                                Map.of("contains", "xyz"),
+                                Map.of("contains", "defg")
+                            )
+                        )
+                    )
+                );
+                getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+            }
+        }
+
+        @DisplayName("with matcher 'list'")
+        @Nested
+        public class ListMatcher {
+            private final String contextValueOne = "abcdefg";
+            private final String contextValueTwo = "hijklmn";
+            private final String contextValueThree = "opqrstu";
+            private String context;
+
+            @BeforeEach
+            void setup() {
+                createPostStub();
+                context = postAndAssertContextValue(contextValueOne);
+                postAndAssertContextValue(context, contextValueTwo);
+                postAndAssertContextValue(context, contextValueThree);
+            }
+
+            @DisplayName("fails on invalid built-in matchers")
+            @Test
+            void test_evaluateBuiltinMatchers_fail() {
+                createGetStub("list",
+                    Map.of(
+                        "0",
+                        Map.of("stateValue", Map.of("contains", Map.of("invalid", "invalid")))
+                    )
+                );
+                getAndAssertContextMatcher(context, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            }
+
+            @DisplayName("can evaluate built-in matchers")
+            @Test
+            void test_evaluateBuiltinMatchers_ok() {
+                createGetStub(
+                    "list",
+                    Map.of(
+                        "0",
+                        Map.of("stateValue", Map.of("contains", "defg"))
+                    )
+                );
+                getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+            }
+
+
+            @DisplayName("fails on unmatched built-in matchers")
+            @Test
+            void test_failingBuiltinMatchers_fail() {
+                createGetStub(
+                    "list",
+                    Map.of(
+                        "0",
+                        Map.of("stateValue", Map.of("contains", "1111"))
+                    )
+                );
+
+                getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+            }
+
+            @DisplayName("Can access individual ist elements")
+            @TestFactory
+            List<DynamicTest> test_accessListElements_ok() {
+                return Map.of("first", "defg", "last", "qrs", "0", "defg", "-1", "qrs", "1", "jkl")
+                    .entrySet()
+                    .stream()
+                    .map(entry ->
+                        DynamicTest.dynamicTest(entry.getKey(), () -> {
+                            createGetStub(
+                                "list",
+                                Map.of(
+                                    entry.getKey(),
+                                    Map.of("stateValue", Map.of("contains", entry.getValue()))
+                                )
+                            );
+                            getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+                        })
+                    ).collect(Collectors.toList());
+            }
+
+            @DisplayName("fails when accessing unknown list element")
+            @Test
+            void test_withInvalidListElement_fail() {
+                createGetStub(
+                    "list",
+                    Map.of(
+                        "100",
+                        Map.of("stateValue", Map.of("contains", "defg"))
+                    )
+                );
+                getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+            }
+
+            @DisplayName("can evaluate nested built-in matchers")
+            @Test
+            void test_evaluateNestedBuiltinMatchers_ok() {
+                createGetStub(
+                    "list",
+                    Map.of(
+                        "0",
+                        Map.of(
+                            "stateValue",
+                            Map.of("or",
+                                List.of(
+                                    Map.of("contains", "xyz"),
+                                    Map.of("contains", "defg")
+                                )
+                            )
+                        )
+                    )
+                );
+                getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+            }
+        }
+
+        @DisplayName("with updateCount matchers")
         @Nested
         public class UpdateCount {
-            @Test
-            void test_countAndSizeIncreased_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+            private final String contextValue = RandomStringUtils.randomAlphabetic(5);
+            private String context;
 
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "2", "1");
-                postAndAssertContextValue(context, contextValue);
-                getAndAssertContextMatcher(context, "all", HttpStatus.SC_OK, "context found", "4", "2");
+            @BeforeEach
+            void setup() {
+                wm.resetAll();
+                createPostStub();
+                context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, RandomStringUtils.randomAlphabetic(5));
             }
 
-            @Test
-            void test_updateCountEqualTo_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+            @DisplayName("with matcher 'updateCountEqualTo'")
+            @Nested
+            public class UpdateCountEqualTo {
 
-                var context = postAndAssertContextValue(contextValue);
-                postAndAssertContextValue(context, contextValue);
-                postAndAssertContextValue(context, contextValue);
-                getAndAssertContextMatcher(context, "updateCountEqualTo/6", HttpStatus.SC_OK, "context found", "6", "3");
-                getAndAssertContextMatcher(context, "updateCountEqualTo/2", HttpStatus.SC_NOT_FOUND);
+                @DisplayName("succeeds on matching count")
+                @Test
+                void test_countMatches_ok() {
+                    createGetStub("updateCountEqualTo", "4");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+                }
+
+                @DisplayName("succeeds on invalid configuration")
+                @Test
+                void test_countInvalid_fail() {
+                    createGetStub("updateCountEqualTo", "invalid");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+
+                @DisplayName("fails on non-matching count")
+                @Test
+                void test_countDoesNotMatch_fail() {
+                    createGetStub("updateCountEqualTo", "2");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
             }
 
-            @Test
-            void test_listSizeEqualTo_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+            @DisplayName("with matcher 'updateCountLessThan'")
+            @Nested
+            public class UpdateCountLessThan {
 
-                var context = postAndAssertContextValue(contextValue);
-                postAndAssertContextValue(context, contextValue);
-                postAndAssertContextValue(context, contextValue);
-                getAndAssertContextMatcher(context, "listSizeEqualTo/3", HttpStatus.SC_OK, "context found", "6", "3");
-                getAndAssertContextMatcher(context, "listSizeEqualTo/2", HttpStatus.SC_NOT_FOUND);
+                @DisplayName("succeeds on matching count")
+                @Test
+                void test_countMatches_ok() {
+                    createGetStub("updateCountLessThan", "5");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+                }
+
+                @DisplayName("succeeds on invalid configuration")
+                @Test
+                void test_countInvalid_fail() {
+                    createGetStub("updateCountLessThan", "invalid");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+
+                @DisplayName("fails on non-matching count")
+                @Test
+                void test_countDoesNotMatch_fail() {
+                    createGetStub("updateCountLessThan", "4");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
             }
 
-            @Test
-            void test_listSizeEqualTo_invalidInput_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+            @DisplayName("with matcher 'updateCountMoreThan'")
+            @Nested
+            public class UpdateCountMoreThan {
 
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "listSizeEqualTo/invalid", HttpStatus.SC_NOT_FOUND);
-            }
+                @DisplayName("succeeds on matching count")
+                @Test
+                void test_countMatches_ok() {
+                    createGetStub("updateCountMoreThan", "3");
 
-            @Test
-            void test_updateCountLessThan_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+                    getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+                }
 
-                var context = postAndAssertContextValue(contextValue);
-                postAndAssertContextValue(context, contextValue);
-                postAndAssertContextValue(context, contextValue);
-                getAndAssertContextMatcher(context, "updateCountLessThan/7", HttpStatus.SC_OK, "context found", "6", "3");
-                getAndAssertContextMatcher(context, "updateCountLessThan/6", HttpStatus.SC_NOT_FOUND);
-            }
+                @DisplayName("succeeds on invalid configuration")
+                @Test
+                void test_countInvalid_fail() {
+                    createGetStub("updateCountMoreThan", "invalid");
 
-            @Test
-            void test_updateCountLessThan_invalidInput_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
 
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "updateCountLessThan/invalid", HttpStatus.SC_NOT_FOUND);
-            }
+                @DisplayName("fails on non-matching count")
+                @Test
+                void test_countDoesNotMatch_fail() {
+                    createGetStub("updateCountMoreThan", "4");
 
-            @Test
-            void test_listSizeLessThan_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                postAndAssertContextValue(context, contextValue);
-                postAndAssertContextValue(context, contextValue);
-                getAndAssertContextMatcher(context, "listSizeLessThan/4", HttpStatus.SC_OK, "context found", "6", "3");
-                getAndAssertContextMatcher(context, "listSizeLessThan/3", HttpStatus.SC_NOT_FOUND);
-            }
-
-            @Test
-            void test_listSizeLessThan_invalidInput_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "listSizeLessThan/invalid", HttpStatus.SC_NOT_FOUND);
-            }
-
-            @Test
-            void test_updateCountMoreThan_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                postAndAssertContextValue(context, contextValue);
-                postAndAssertContextValue(context, contextValue);
-                getAndAssertContextMatcher(context, "updateCountMoreThan/5", HttpStatus.SC_OK, "context found", "6", "3");
-                getAndAssertContextMatcher(context, "updateCountMoreThan/6", HttpStatus.SC_NOT_FOUND);
-            }
-
-            @Test
-            void test_updateCountMoreThan_invalidInput_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "updateCountMoreThan/invalid", HttpStatus.SC_NOT_FOUND);
-            }
-
-            @Test
-            void test_listSizeMoreThan_ok() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                postAndAssertContextValue(context, contextValue);
-                postAndAssertContextValue(context, contextValue);
-                getAndAssertContextMatcher(context, "listSizeMoreThan/2", HttpStatus.SC_OK, "context found", "6", "3");
-                getAndAssertContextMatcher(context, "listSizeMoreThan/3", HttpStatus.SC_NOT_FOUND);
-            }
-
-            @Test
-            void test_listSizeMoreThan_invalidInput_fail() {
-                var contextValue = RandomStringUtils.randomAlphabetic(5);
-
-                var context = postAndAssertContextValue(contextValue);
-                getAndAssertContextMatcher(context, "listSizeMoreThan/invalid", HttpStatus.SC_NOT_FOUND);
-            }
-
-            @Test
-            void test_multipleContexts_updateAndSizeIncreasedIndividually_ok() {
-                var contextValueOne = RandomStringUtils.randomAlphabetic(5);
-                var contextValueTwo = RandomStringUtils.randomAlphabetic(5);
-
-                var contextOne = postAndAssertContextValue(contextValueOne);
-                var contextTwo = postAndAssertContextValue(contextValueTwo);
-
-                getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "2", "1");
-                getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
-
-                postAndAssertContextValue(contextOne, contextValueOne);
-                getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "4", "2");
-                getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "2", "1");
-
-                postAndAssertContextValue(contextTwo, contextValueTwo);
-                getAndAssertContextMatcher(contextOne, "all", HttpStatus.SC_OK, "context found", "4", "2");
-                getAndAssertContextMatcher(contextTwo, "all", HttpStatus.SC_OK, "context found", "4", "2");
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
             }
         }
 
+        @DisplayName("with listSize matchers")
+        @Nested
+        public class ListSize {
+
+            private final String contextValue = RandomStringUtils.randomAlphabetic(5);
+            private String context;
+
+            @BeforeEach
+            void setup() {
+                wm.resetAll();
+                createPostStub();
+                context = postAndAssertContextValue(contextValue);
+                postAndAssertContextValue(context, RandomStringUtils.randomAlphabetic(5));
+            }
+
+            @DisplayName("with matcher 'listSizeEqualTo'")
+            @Nested
+            public class UpdateCountEqualTo {
+
+                @DisplayName("succeeds on matching count")
+                @Test
+                void test_countMatches_ok() {
+                    createGetStub("listSizeEqualTo", "2");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+                }
+
+                @DisplayName("succeeds on invalid configuration")
+                @Test
+                void test_countInvalid_fail() {
+                    createGetStub("listSizeEqualTo", "invalid");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+
+                @DisplayName("fails on non-matching count")
+                @Test
+                void test_countDoesNotMatch_fail() {
+                    createGetStub("listSizeEqualTo", "3");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+            }
+
+            @DisplayName("with matcher 'listSizeLessThan'")
+            @Nested
+            public class UpdateCountLessThan {
+
+                @DisplayName("succeeds on matching count")
+                @Test
+                void test_countMatches_ok() {
+                    createGetStub("listSizeLessThan", "3");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+                }
+
+                @DisplayName("succeeds on invalid configuration")
+                @Test
+                void test_countInvalid_fail() {
+                    createGetStub("listSizeLessThan", "invalid");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+
+                @DisplayName("fails on non-matching count")
+                @Test
+                void test_countDoesNotMatch_fail() {
+                    createGetStub("listSizeLessThan", "2");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+            }
+
+            @DisplayName("with matcher 'listSizeMoreThan'")
+            @Nested
+            public class UpdateCountMoreThan {
+
+                @DisplayName("succeeds on matching count")
+                @Test
+                void test_countMatches_ok() {
+                    createGetStub("listSizeMoreThan", "1");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_OK);
+                }
+
+                @DisplayName("succeeds on invalid configuration")
+                @Test
+                void test_countInvalid_fail() {
+                    createGetStub("listSizeMoreThan", "invalid");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+
+                @DisplayName("fails on non-matching count")
+                @Test
+                void test_countDoesNotMatch_fail() {
+                    createGetStub("listSizeMoreThan", "2");
+
+                    getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- adding `property` configuration for request matching
- adding `list` configuration for request matching
- supporting WireMock's built-in matchers for request matching
- cleaned template helper tests to be more elaborate
- cleaned up state request matcher tests to be more elaborate

<!-- Please describe your pull request here. -->

## References

#64 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
