### PR TITLE
bug!: fix updateCount handling

### DIFF
--- a/src/main/java/org/wiremock/extensions/state/extensions/StateHandlerbarHelper.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/StateHandlerbarHelper.java
@@ -22,7 +22,7 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.Hand
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.commons.lang3.StringUtils;
-import org.wiremock.extensions.state.internal.Context;
+import org.wiremock.extensions.state.internal.model.Context;
 import org.wiremock.extensions.state.internal.ContextManager;
 
 import java.util.ArrayList;
@@ -84,7 +84,7 @@ public class StateHandlerbarHelper extends HandlebarsHelper<Object> {
     }
 
     private Optional<Object> getProperty(String contextName, String property, String defaultValue) {
-        return contextManager.getContext(contextName)
+        return contextManager.getContextCopy(contextName)
             .map(context ->
                 Stream.of(SpecialProperties.values())
                     .filter(it -> it.name().equals(property))
@@ -111,7 +111,7 @@ public class StateHandlerbarHelper extends HandlebarsHelper<Object> {
     }
 
     private Optional<Object> getList(String contextName, String list) {
-        return contextManager.getContext(contextName)
+        return contextManager.getContextCopy(contextName)
             .flatMap(context -> {
                 try {
                     return Optional.of(JsonPath.read(context.getList(), list));

--- a/src/main/java/org/wiremock/extensions/state/extensions/StateRequestMatcher.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/StateRequestMatcher.java
@@ -21,13 +21,12 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.RequestTemplateModel;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.matching.ContentPattern;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
-import org.wiremock.extensions.state.internal.Context;
+import org.wiremock.extensions.state.internal.model.Context;
 import org.wiremock.extensions.state.internal.ContextManager;
-import org.wiremock.extensions.state.internal.ContextTemplateModel;
+import org.wiremock.extensions.state.internal.model.ContextTemplateModel;
 import org.wiremock.extensions.state.internal.StateExtensionMixin;
 
 import java.util.Arrays;
@@ -107,7 +106,7 @@ public class StateRequestMatcher extends RequestMatcherExtension implements Stat
     }
 
     private MatchResult hasContext(Map<String, Object> model, Parameters parameters, String template) {
-        return contextManager.getContext(renderTemplate(model, template))
+        return contextManager.getContextCopy(renderTemplate(model, template))
             .map(context -> {
                 List<Map.Entry<ContextMatcher, Object>> matchers = getMatchers(parameters);
                 if (matchers.isEmpty()) {
@@ -131,7 +130,7 @@ public class StateRequestMatcher extends RequestMatcherExtension implements Stat
 
     private MatchResult hasNotContext(Map<String, Object> model, String template) {
         var context = renderTemplate(model, template);
-        if (contextManager.getContext(context).isEmpty()) {
+        if (contextManager.getContextCopy(context).isEmpty()) {
             logger().info(context, "hasNotContext matched");
             return MatchResult.exactMatch();
         } else {

--- a/src/main/java/org/wiremock/extensions/state/extensions/TransactionEventListener.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/TransactionEventListener.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Dirk Bolte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.extensions.state.extensions;
+
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ServeEventListener;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.extensions.state.internal.ContextManager;
+import org.wiremock.extensions.state.internal.StateExtensionMixin;
+import org.wiremock.extensions.state.internal.TransactionManager;
+
+/**
+ * Persist transaction-related information in the context.
+ * <p>
+ * DO NOT REGISTER directly. Use {@link org.wiremock.extensions.state.StateExtension} instead.
+ *
+ * @see org.wiremock.extensions.state.StateExtension
+ */
+public class TransactionEventListener implements ServeEventListener, StateExtensionMixin {
+
+    private final TransactionManager transactionManager;
+
+
+    public TransactionEventListener(TransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
+    @Override
+    public String getName() {
+        return "stateTransaction";
+    }
+
+    @Override
+    public boolean applyGlobally() {
+        return true;
+    }
+
+    @Override
+    public void afterComplete(ServeEvent serveEvent, Parameters parameters) {
+
+        String requestId = serveEvent.getId().toString();
+        var contextNames = transactionManager.getContextNamesByRequestId(requestId);
+        contextNames.forEach((contextName) -> transactionManager.deleteTransaction(requestId, contextName));
+
+    }
+}

--- a/src/main/java/org/wiremock/extensions/state/internal/ExtensionLogger.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/ExtensionLogger.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright (C) 2023 Dirk Bolte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wiremock.extensions.state.internal;
+
+import org.wiremock.extensions.state.internal.model.Context;
 
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 

--- a/src/main/java/org/wiremock/extensions/state/internal/TransactionManager.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/TransactionManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 Dirk Bolte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.extensions.state.internal;
+
+import com.github.tomakehurst.wiremock.store.Store;
+import org.wiremock.extensions.state.internal.model.Transaction;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class TransactionManager {
+
+    private final String TRANSACTION_KEY_PREFIX = "transaction:";
+    private final Store<String, Object> store;
+
+    public TransactionManager(Store<String, Object> store) {
+        this.store = store;
+    }
+
+    public <T> T withTransaction(String requestId, String contextName, Function<Transaction, T> function) {
+        var transactionKey = createTransactionKey(requestId);
+        synchronized (store) {
+            @SuppressWarnings("unchecked") var requestTransactions = store.get(transactionKey).map(it -> (Map<String, Transaction>) it).orElse(new HashMap<>());
+            var contextTransaction = requestTransactions.getOrDefault(contextName, new Transaction(contextName));
+            try {
+                return function.apply(contextTransaction);
+            } finally {
+                requestTransactions.put(contextName, contextTransaction);
+                store.put(transactionKey, requestTransactions);
+            }
+        }
+    }
+
+    public void withTransaction(String requestId, String contextName, Consumer<Transaction> consumer) {
+        var transactionKey = createTransactionKey(requestId);
+        synchronized (store) {
+            @SuppressWarnings("unchecked") var requestTransactions = store.get(transactionKey).map(it -> (Map<String, Transaction>) it).orElse(new HashMap<>());
+            var contextTransaction = requestTransactions.getOrDefault(contextName, new Transaction(contextName));
+            try {
+                consumer.accept(contextTransaction);
+            } finally {
+                requestTransactions.put(contextName, contextTransaction);
+                store.put(transactionKey, requestTransactions);
+            }
+        }
+    }
+
+    public void deleteTransaction(String requestId, String contextName) {
+        var transactionKey = createTransactionKey(requestId);
+        synchronized (store) {
+            @SuppressWarnings("unchecked") var requestTransactions = store.get(transactionKey).map(it -> (Map<String, Transaction>) it).orElse(new HashMap<>());
+            requestTransactions.remove(contextName);
+        }
+    }
+
+    public Set<String> getContextNamesByRequestId(String requestId) {
+        var transactionKey = createTransactionKey(requestId);
+        synchronized (store) {
+            @SuppressWarnings("unchecked") var requestTransactions = store.get(transactionKey).map(it -> (Map<String, Transaction>) it).orElse(new HashMap<>());
+            return requestTransactions.keySet();
+        }
+    }
+
+    private String createTransactionKey(String requestId) {
+        return TRANSACTION_KEY_PREFIX + requestId;
+    }
+
+
+}

--- a/src/main/java/org/wiremock/extensions/state/internal/api/DeleteStateParameters.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/api/DeleteStateParameters.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wiremock.extensions.state.internal;
+package org.wiremock.extensions.state.internal.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/src/main/java/org/wiremock/extensions/state/internal/api/RecordStateParameters.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/api/RecordStateParameters.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wiremock.extensions.state.internal;
+package org.wiremock.extensions.state.internal.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/src/main/java/org/wiremock/extensions/state/internal/api/StateRequestMatcherParameters.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/api/StateRequestMatcherParameters.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wiremock.extensions.state.internal;
+package org.wiremock.extensions.state.internal.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/src/main/java/org/wiremock/extensions/state/internal/model/Context.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/model/Context.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wiremock.extensions.state.internal;
+package org.wiremock.extensions.state.internal.model;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -22,13 +22,11 @@ import java.util.stream.Collectors;
 
 public class Context {
 
-    private static final int MAX_IDS = 10;
     private final String contextName;
     private final Map<String, String> properties = new HashMap<>();
     private final LinkedList<Map<String, String>> list = new LinkedList<>();
     private final LinkedList<String> requests = new LinkedList<>();
-    private Long updateCount = 1L;
-    private Long matchCount = 0L;
+    private Long updateCount = 0L;
 
     public Context(Context other) {
         this.contextName = other.contextName;
@@ -36,7 +34,6 @@ public class Context {
         this.list.addAll(other.list.stream().map(HashMap::new).collect(Collectors.toList()));
         this.requests.addAll(other.requests);
         this.updateCount = other.updateCount;
-        this.matchCount = other.matchCount;
     }
 
     public Context(String contextName) {
@@ -51,26 +48,9 @@ public class Context {
         return updateCount;
     }
 
-    public Long getMatchCount() {
-        return matchCount;
-    }
-
     public Long incUpdateCount() {
         updateCount = updateCount + 1;
         return updateCount;
-    }
-
-    public Long incMatchCount(String requestId) {
-        if (requests.contains(requestId)) {
-            return matchCount;
-        } else {
-            requests.add(requestId);
-            if (requests.size() > MAX_IDS) {
-                requests.removeFirst();
-            }
-            matchCount = matchCount + 1;
-            return matchCount;
-        }
     }
 
     public Map<String, String> getProperties() {

--- a/src/main/java/org/wiremock/extensions/state/internal/model/ContextTemplateModel.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/model/ContextTemplateModel.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Dirk Bolte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.extensions.state.internal.model;
+
+@SuppressWarnings("unused")
+public final class ContextTemplateModel {
+
+    private final Context context;
+
+    private ContextTemplateModel(Context context) {
+        this.context = context;
+    }
+
+    public static ContextTemplateModel from(Context context) {
+        return new ContextTemplateModel(context);
+    }
+
+
+    public Long getUpdateCount() {
+        return context.getUpdateCount();
+    }
+}

--- a/src/main/java/org/wiremock/extensions/state/internal/model/ResponseTemplateModel.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/model/ResponseTemplateModel.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wiremock.extensions.state.internal;
+package org.wiremock.extensions.state.internal.model;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 import com.github.tomakehurst.wiremock.http.LoggedResponse;

--- a/src/main/java/org/wiremock/extensions/state/internal/model/Transaction.java
+++ b/src/main/java/org/wiremock/extensions/state/internal/model/Transaction.java
@@ -13,26 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wiremock.extensions.state.internal;
+package org.wiremock.extensions.state.internal.model;
 
-public final class ContextTemplateModel {
+import java.util.function.Consumer;
 
-    private final Context context;
+public class Transaction {
+    private final String contextName;
+    private Boolean writeRecorded = false;
 
-    private ContextTemplateModel(Context context) {
-        this.context = context;
+    public Transaction(String contextName) {
+        this.contextName = contextName;
     }
 
-    public static ContextTemplateModel from(Context context) {
-        return new ContextTemplateModel(context);
+    public void recordWrite(Runnable runnable) {
+        if(!writeRecorded) {
+            runnable.run();
+            writeRecorded = true;
+        }
     }
-
-
-    public Long getReadCount() {
-        return context.getMatchCount();
-    }
-
-    public Long getUpdateCount() {
-        return context.getUpdateCount();
+    public String getContextName() {
+        return contextName;
     }
 }

--- a/src/test/java/org/wiremock/extensions/state/functionality/AbstractTestBase.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/AbstractTestBase.java
@@ -28,8 +28,10 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.wiremock.extensions.state.CaffeineStore;
 import org.wiremock.extensions.state.StateExtension;
 import org.wiremock.extensions.state.internal.ContextManager;
+import org.wiremock.extensions.state.internal.TransactionManager;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +43,8 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 public class AbstractTestBase {
     protected static final ObjectMapper mapper = new ObjectMapper();
     protected static final CaffeineStore store = new CaffeineStore();
-    protected static final ContextManager contextManager = new ContextManager(store);
+    protected static final TransactionManager transactionManager = new TransactionManager(store);
+    protected static final ContextManager contextManager = new ContextManager(store, transactionManager);
 
     @RegisterExtension
     public static WireMockExtension wm = WireMockExtension.newInstance()
@@ -60,7 +63,7 @@ public class AbstractTestBase {
     @BeforeEach
     void setupBase() {
         wm.resetAll();
-        contextManager.deleteAllContexts();
+        contextManager.deleteAllContexts(UUID.randomUUID().toString());
     }
 
     protected void assertContextNumUpdates(String context, int expected) {

--- a/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
@@ -534,7 +534,7 @@ class StateRequestMatcherTest extends AbstractTestBase {
                 @DisplayName("succeeds on matching count")
                 @Test
                 void test_countMatches_ok() {
-                    createGetStub("updateCountEqualTo", "4");
+                    createGetStub("updateCountEqualTo", "2");
 
                     getAndAssertContextMatcher(context, HttpStatus.SC_OK);
                 }
@@ -550,7 +550,7 @@ class StateRequestMatcherTest extends AbstractTestBase {
                 @DisplayName("fails on non-matching count")
                 @Test
                 void test_countDoesNotMatch_fail() {
-                    createGetStub("updateCountEqualTo", "2");
+                    createGetStub("updateCountEqualTo", "1");
 
                     getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
                 }
@@ -563,7 +563,7 @@ class StateRequestMatcherTest extends AbstractTestBase {
                 @DisplayName("succeeds on matching count")
                 @Test
                 void test_countMatches_ok() {
-                    createGetStub("updateCountLessThan", "5");
+                    createGetStub("updateCountLessThan", "3");
 
                     getAndAssertContextMatcher(context, HttpStatus.SC_OK);
                 }
@@ -579,7 +579,7 @@ class StateRequestMatcherTest extends AbstractTestBase {
                 @DisplayName("fails on non-matching count")
                 @Test
                 void test_countDoesNotMatch_fail() {
-                    createGetStub("updateCountLessThan", "4");
+                    createGetStub("updateCountLessThan", "2");
 
                     getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
                 }
@@ -592,7 +592,7 @@ class StateRequestMatcherTest extends AbstractTestBase {
                 @DisplayName("succeeds on matching count")
                 @Test
                 void test_countMatches_ok() {
-                    createGetStub("updateCountMoreThan", "3");
+                    createGetStub("updateCountMoreThan", "1");
 
                     getAndAssertContextMatcher(context, HttpStatus.SC_OK);
                 }
@@ -608,7 +608,7 @@ class StateRequestMatcherTest extends AbstractTestBase {
                 @DisplayName("fails on non-matching count")
                 @Test
                 void test_countDoesNotMatch_fail() {
-                    createGetStub("updateCountMoreThan", "4");
+                    createGetStub("updateCountMoreThan", "2");
 
                     getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
                 }

--- a/src/test/java/org/wiremock/extensions/state/functionality/StateTemplateHelperProviderExtensionTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/StateTemplateHelperProviderExtensionTest.java
@@ -286,7 +286,7 @@ class StateTemplateHelperProviderExtensionTest extends AbstractTestBase {
         public void setup() {
             createContextStatePostStub(Map.of());
             postContext(contextName, Map.of());
-            assertThat(contextManager.getContext(contextName)).isPresent();
+            assertThat(contextManager.getContextCopy(contextName)).isPresent();
         }
 
         @DisplayName("when no default is specified returns empty string")
@@ -331,7 +331,7 @@ class StateTemplateHelperProviderExtensionTest extends AbstractTestBase {
         public void setup() {
             createContextStatePostStub(Map.of());
             postContext(contextName, Map.of());
-            assertThat(contextManager.getContext(contextName)).isPresent();
+            assertThat(contextManager.getContextCopy(contextName)).isPresent();
         }
 
         @DisplayName("when accessing first element")


### PR DESCRIPTION
- introduce a pseudo-transaction which writes updates when a request ends
- introduce a transactionManager for this
- move locking to transactionManager (and remove some unneeded locks)
- update tests as the updateCount is only increased once now

<!-- Please describe your pull request here. -->

## References

#102 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
