### PR TITLE
doc: correct documentation to store and retrieve a full body

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Full example for storing a state:
 }
 ```
 
-To record a complete response body, use:
+To record a complete response body, use (**ATTENTION**: tripple `{{{`):
 
 ```json
 {
@@ -422,7 +422,7 @@ To record a complete response body, use:
       "parameters": {
         "context": "{{jsonPath response.body '$.id'}}",
         "state": {
-          "fullBody": "{{jsonPath response.body '$'}}"
+          "fullBody": "{{{jsonPath response.body '$'}}}"
         }
       }
     }

--- a/src/test/java/org/wiremock/extensions/state/functionality/StateTemplateHelperProviderExtensionTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/StateTemplateHelperProviderExtensionTest.java
@@ -578,6 +578,20 @@ class StateTemplateHelperProviderExtensionTest extends AbstractTestBase {
             getContext(contextName, (result) -> assertThat(result).containsExactlyEntriesOf(request));
         }
 
+
+        @DisplayName("returns body from previous request")
+        @Test
+        void test_returnsBody() {
+            Map<String, Object> request = Map.of("contextValue", "aContextValue", "otherKey", "otherValue");
+            createContextStatePostStub(Map.of("fullBody", "{{{jsonPath request.body '$'}}}"));
+            createContextGetStub("{{{state context=request.pathSegments.[1] property='fullBody' }}}");
+
+            var expectedResult = new HashMap<>(request);
+            expectedResult.put("contextName", contextName);
+            postContext(contextName, request);
+            getContext(contextName, (result) -> assertThat(result).containsExactlyInAnyOrderEntriesOf(expectedResult));
+        }
+
         @DisplayName("with default specified returns property from previous request")
         @Test
         void test_withDefaultReturnsState() {


### PR DESCRIPTION
- provided test case to ensure functionality

<!-- Please describe your pull request here. -->

## References

#115 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
