### PR TITLE
fix: support accessing query parameters for state handlebar extension

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,3 +70,26 @@ jobs:
         with:
           name: jacoco-report
           path: build/reports/jacoco/
+
+  archive:
+    name: Archive job results
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+      - name: Run the Gradle package task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jar shadowjar
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jars
+          path: |
+            build/libs/*.jar

--- a/src/main/java/org/wiremock/extensions/state/extensions/StateHandlerbarHelper.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/StateHandlerbarHelper.java
@@ -51,10 +51,10 @@ public class StateHandlerbarHelper extends HandlebarsHelper<Object> {
 
     @Override
     public Object apply(Object o, Options options) {
-        String contextName = options.hash("context");
-        String property = options.hash("property");
-        String list = options.hash("list");
-        String defaultValue = options.hash("default");
+        String contextName = Optional.ofNullable(options.hash("context")).map(Object::toString).orElse(null);
+        String property = Optional.ofNullable(options.hash("property")).map(Object::toString).orElse(null);
+        String list = Optional.ofNullable(options.hash("list")).map(Object::toString).orElse(null);
+        String defaultValue = Optional.ofNullable(options.hash("default")).map(Object::toString).orElse(null);
         if (StringUtils.isEmpty(contextName)) {
             return handleError("'context' cannot be empty");
         }


### PR DESCRIPTION
- always call `toString` when accessing an option hash

<!-- Please describe your pull request here. -->

## References

- #126

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
