### PR TITLE
add numeric comparison request matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,6 +1052,113 @@ Example for nesting:
   }
 ```
 
+### Numeric comparisons match
+
+You can perform numeric comparisons on state properties using the `numericComparisons` matcher. This allows you to match requests based on numeric conditions for specific properties in the context.
+
+The following comparison operators are supported:
+
+- `gt` - greater than
+- `gte` - greater than or equal to  
+- `lt` - less than
+- `lte` - less than or equal to
+- `eq` - equal to
+- `ne` - not equal to
+
+Both constant values and state property values (via templating) can be used as comparison values.
+
+**Basic example with constant values:**
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/test/[^\/]+",
+    "customMatcher": {
+      "name": "state-matcher",
+      "parameters": {
+        "hasContext": "{{request.pathSegments.[1]}}",
+        "numericComparisons": {
+          "amount": {
+            "gt": "0",
+            "lte": "100"
+          }
+        }
+      }
+    }
+  },
+  "response": {
+    "status": 200
+  }
+}
+```
+
+**Advanced example with state property values:**
+
+```json
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/transfer",
+    "customMatcher": {
+      "name": "state-matcher",
+      "parameters": {
+        "hasContext": "{{jsonPath request.body '$.id'}}",
+        "numericComparisons": {
+          "amount": {
+            "gt": "500",
+            "lte": "{{state context=(jsonPath request.body '$.id') property='balance'}}"
+          }
+        }
+      }
+    }
+  },
+  "response": {
+    "status": 200
+  }
+}
+```
+
+**Multiple property comparisons:**
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/account/[^\/]+",
+    "customMatcher": {
+      "name": "state-matcher",
+      "parameters": {
+        "hasContext": "{{request.pathSegments.[2]}}",
+        "numericComparisons": {
+          "balance": {
+            "gte": "0"
+          },
+          "transactionCount": {
+            "lt": "1000"
+          },
+          "dailyLimit": {
+            "eq": "{{state context=request.pathSegments.[2] property='defaultLimit'}}"
+          }
+        }
+      }
+    }
+  },
+  "response": {
+    "status": 200
+  }
+}
+```
+
+**Notes:**
+
+- All numeric values should be provided as strings (consistent with WireMock's templating system)
+- Templating is fully supported in comparison values
+- Multiple conditions for the same property are combined with AND logic
+- Multiple properties are combined with AND logic
+- If a property doesn't exist or cannot be converted to a number, the match will fail
+- This matcher can be combined with other state matchers like `hasContext`, `hasProperty`, etc.
+
 ## Retrieve a state
 
 A state can be retrieved using a handlebar helper. In the example above, the `StateHelper` is registered by the name `state`.

--- a/src/main/java/org/wiremock/extensions/state/extensions/requestmatcher/ComparisonOperator.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/requestmatcher/ComparisonOperator.java
@@ -1,0 +1,74 @@
+package org.wiremock.extensions.state.extensions.requestmatcher;
+
+/**
+ * Comparison operators for numeric and comparable value comparisons.
+ */
+public enum ComparisonOperator {
+    eq,
+    ne,
+    lt,
+    lte,
+    gt,
+    gte;
+
+    /**
+     * Compares two numeric values using this operator.
+     * Converts numbers to Double for comparison to handle different numeric types.
+     *
+     * @param a first number to compare
+     * @param b second number to compare
+     * @return true if the comparison condition is satisfied
+     * @throws IllegalArgumentException if null values cannot be compared with this operator
+     */
+    public <T extends Number> boolean compare(T a, T b) {
+
+        if (a == null && b == null) {
+            if (this == eq) return true;
+            if (this == ne) return false;
+        }
+
+        if (a == null || b == null) {
+            if (this == eq) return false;
+            if (this == ne) return true;
+            throw new IllegalArgumentException(
+                String.format("Cannot compare %s with %s using operator %s", a, b, this)
+            );
+        }
+
+        double valueA = a.doubleValue();
+        double valueB = b.doubleValue();
+
+        switch (this) {
+            case eq:
+                return valueA == valueB;
+            case ne:
+                return valueA != valueB;
+            case lt:
+                return valueA < valueB;
+            case lte:
+                return valueA <= valueB;
+            case gt:
+                return valueA > valueB;
+            case gte:
+                return valueA >= valueB;
+            default:
+                throw new IllegalStateException("Unsupported operator: " + this);
+        }
+    }
+
+    /**
+     * Returns the ComparisonOperator for the given name.
+     * Name matching is case-insensitive (e.g., "EQ", "eq", "Eq" all work).
+     *
+     * @param name the operator name (eq, ne, lt, lte, gt, gte)
+     * @return the corresponding ComparisonOperator
+     * @throws IllegalArgumentException if the name does not match any operator
+     */
+    public static ComparisonOperator fromName(String name) {
+        try {
+            return valueOf(name.toLowerCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown operator name: " + name);
+        }
+    }
+}

--- a/src/main/java/org/wiremock/extensions/state/extensions/requestmatcher/StateRequestMatcher.java
+++ b/src/main/java/org/wiremock/extensions/state/extensions/requestmatcher/StateRequestMatcher.java
@@ -290,6 +290,30 @@ public class StateRequestMatcher extends RequestMatcherExtension implements Stat
         listSizeMoreThan((Context c, Object object) -> {
             String stringValue = cast(object, String.class);
             return toMatchResult(withConvertedNumber(c, stringValue, (context, value) -> context.getList().size() > value));
+        }),
+        numericComparisons((Context c, Object object) -> {
+            @SuppressWarnings("unchecked") Map<String, Map<String, String>> mapValue = cast(object, Map.class);
+            Map<String, String> properties = c.getProperties();
+            boolean result = mapValue.entrySet().stream()
+                .allMatch(e -> {
+                    String propertyName = e.getKey();
+                    String propertyValueString = properties.get(propertyName);
+                    double actual = castToDouble(propertyValueString);
+                    return e.getValue().entrySet().stream()
+                        .allMatch(me -> {
+                            double expected = castToDouble(me.getValue());
+                            try {
+                                ComparisonOperator operator = ComparisonOperator.fromName(me.getKey());
+                                return operator.compare(actual, expected);
+                            } catch (IllegalArgumentException | IllegalStateException ex) {
+                                String msg = String.format("Cannot compare %s and %s: %s", actual, expected, ex.getMessage());
+                                String prefixed = String.format("%s: %s", "StateRequestMatcher", msg);
+                                notifier().error(prefixed);
+                                throw new ConfigurationException(prefixed);
+                            }
+                        });
+                });
+            return toMatchResult(result);
         });
 
         private final BiFunction<Context, Object, MatchResult> evaluator;
@@ -321,6 +345,17 @@ public class StateRequestMatcher extends RequestMatcherExtension implements Stat
                 return getter.apply(context, longValue);
             } catch (NumberFormatException | IndexOutOfBoundsException ex) {
                 return null;
+            }
+        }
+
+        private static double castToDouble(String stringValue) {
+            try {
+                return Double.parseDouble(stringValue);
+            } catch (NumberFormatException ex) {
+                String msg = String.format("Cannot convert string %s to double: %s", stringValue, ex.getMessage());
+                String prefixed = String.format("%s: %s", "StateRequestMatcher", msg);
+                notifier().error(prefixed);
+                throw new ConfigurationException(prefixed);
             }
         }
 

--- a/src/test/java/org/wiremock/extensions/state/examples/ComparePropertyRequestMatcherExampleTest.java
+++ b/src/test/java/org/wiremock/extensions/state/examples/ComparePropertyRequestMatcherExampleTest.java
@@ -1,0 +1,186 @@
+package org.wiremock.extensions.state.examples;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.store.Store;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.wiremock.extensions.state.CaffeineStore;
+import org.wiremock.extensions.state.StateExtension;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+/**
+ * Sample test for using this compare numeric property request matching.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(SAME_THREAD)
+class ComparePropertyRequestMatcherExampleTest {
+
+    private static final String TEST_URLENC_URL = "/test-urlenc";
+    private static final String TEST_JSON_URL = "/test-json";
+    private static final Store<String, Object> store = new CaffeineStore();
+
+    @RegisterExtension
+    public static WireMockExtension wm = WireMockExtension.newInstance()
+        .options(
+            wireMockConfig().dynamicPort().dynamicHttpsPort().templatingEnabled(true).globalTemplating(true)
+                .extensions(new StateExtension(store))
+                .notifier(new ConsoleNotifier(true))
+        )
+        .build();
+
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        firstStubUrlenc();
+        firstStubJson();
+        secondStubUrlenc();
+        secondStubJson();
+    }
+
+    @Test
+    public void testUrlenc() {
+        var id = given()
+            .accept(ContentType.URLENC)
+            .body("clientId=" + UUID.randomUUID() + "&amount=1000")
+            .post(assertDoesNotThrow(() -> new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_URLENC_URL)))
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .body("id", Matchers.notNullValue())
+            .extract()
+            .body()
+            .jsonPath().get("id");
+
+        given()
+            .accept(ContentType.URLENC)
+            .body("id=" + id + "&amount=1000")
+            .post(assertDoesNotThrow(() -> new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_URLENC_URL)))
+            .then()
+            .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testJson() {
+        var id = given()
+            .accept(ContentType.JSON)
+            .body("{\"clientId\":\"" + UUID.randomUUID() + "\"}")
+            .post(assertDoesNotThrow(() -> new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_JSON_URL)))
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .body("id", Matchers.notNullValue())
+            .extract()
+            .body()
+            .jsonPath().get("id");
+
+        given()
+            .accept(ContentType.URLENC)
+            .body("{\"id\":\"" + id + "\", \"amount\": 1000}")
+            .post(assertDoesNotThrow(() -> new URI(wm.getRuntimeInfo().getHttpBaseUrl() + TEST_JSON_URL)))
+            .then()
+            .statusCode(HttpStatus.SC_OK);
+    }
+
+    private void firstStubUrlenc() {
+        wm.stubFor(post(urlEqualTo(TEST_URLENC_URL))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"id\": \"{{randomValue type='UUID'}}\"}")
+            )
+            .withServeEventListener("recordState",
+                Parameters.from(
+                    Map.of(
+                        "context", "{{jsonPath response.body '$.id'}}",
+                        "state", Map.of(
+                            "id", "{{jsonPath response.body '$.id'}}",
+                            "clientId", "{{formData request.body 'form' urlDecode=true}}{{form.clientId}}",
+                            "amount", "{{formData request.body 'form' urlDecode=true}}{{form.amount}}"
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private void firstStubJson() {
+        wm.stubFor(post(urlEqualTo(TEST_JSON_URL))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"id\": \"{{randomValue type='UUID'}}\"}")
+            )
+            .withServeEventListener("recordState",
+                Parameters.from(
+                    Map.of(
+                        "context", "{{jsonPath response.body '$.id'}}",
+                        "state", Map.of(
+                            "id", "{{jsonPath response.body '$.id'}}",
+                            "clientId", "{{jsonPath request.body '$.clientId'}}",
+                            "amount", "{{jsonPath request.body '$.amount'}}"
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private void secondStubUrlenc() {
+        wm.stubFor(post(urlEqualTo(TEST_URLENC_URL))
+                .andMatching("state-matcher",
+                    Parameters.from(Map.of(
+                        "hasContext", "{{formData request.body 'form' urlDecode=true}}{{form.id}}",
+                        "numericComparisons", Map.of("amount", Map.of(
+                            "lte", "{{#assign 'contextId'}}{{formData request.body 'form' urlDecode=true}}{{form.id}}{{/assign}}{{state context=contextId property='amount'}}",
+                            "gt", "500"
+                            ))
+                        )
+                    )
+                )
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"operationId\": \"{{randomValue type='UUID'}}\"}")
+            )
+        );
+    }
+
+    private void secondStubJson() {
+        wm.stubFor(post(urlEqualTo(TEST_JSON_URL))
+            .andMatching("state-matcher",
+                Parameters.from(Map.of(
+                        "hasContext", "{{jsonPath response.body '$.id'}}",
+                        "numericComparisons", Map.of("amount", Map.of(
+                            "lte", "{{#assign 'contextId'}}{{jsonPath response.body '$.id'}}{{/assign}}{{state context=contextId property='amount'}}",
+                            "gt", "500"
+                        ))
+                    )
+                )
+            )
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"operationId\": \"{{randomValue type='UUID'}}\"}")
+            )
+        );
+    }
+}

--- a/src/test/java/org/wiremock/extensions/state/extensions/requestmatcher/ComparisonOperatorTest.java
+++ b/src/test/java/org/wiremock/extensions/state/extensions/requestmatcher/ComparisonOperatorTest.java
@@ -1,0 +1,173 @@
+package org.wiremock.extensions.state.extensions.requestmatcher;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit-tests for {@link ComparisonOperator}
+ */
+@DisplayName("ComparisonOperator Unit Tests")
+class ComparisonOperatorTest {
+
+    @Nested
+    @DisplayName("Tests for compare() method with numeric values")
+    class CompareTests {
+
+        @DisplayName("eq operator: should return true if numbers are equal, false otherwise")
+        @ParameterizedTest
+        @CsvSource({
+            "20, 10, false",
+            "10, 10, true",
+            "10, 20, false"
+        })
+        void test_eq(int a, int b, boolean result) {
+            assertEquals(result, ComparisonOperator.eq.compare(a, b));
+        }
+
+        @DisplayName("ne operator: should return true if numbers are not equal, false otherwise")
+        @ParameterizedTest
+        @CsvSource({
+            "20, 10, true",
+            "10, 10, false",
+            "10, 20, true"
+        })
+        void test_ne(int a, int b, boolean result) {
+            assertEquals(result, ComparisonOperator.ne.compare(a, b));
+        }
+
+        @DisplayName("lt operator: should return true if first number is less than second")
+        @ParameterizedTest
+        @CsvSource({
+            "20, 10, false",
+            "10, 10, false",
+            "10, 20, true"
+        })
+        void test_lt(int a, int b, boolean result) {
+            assertEquals(result, ComparisonOperator.lt.compare(a, b));
+        }
+
+        @DisplayName("lte operator: should return true if first number is less than or equal to second")
+        @ParameterizedTest
+        @CsvSource({
+            "10, 10, true",
+            "5, 10, true",
+            "10, 5, false"
+        })
+        void test_lte(int a, int b, boolean result) {
+            assertEquals(result, ComparisonOperator.lte.compare(a, b));
+        }
+
+        @DisplayName("gt operator: should return true if first number is greater than second")
+        @ParameterizedTest
+        @CsvSource({
+            "10, 10, false",
+            "5, 10, false",
+            "10, 5, true"
+        })
+        void test_gt(int a, int b, boolean result) {
+            assertEquals(result, ComparisonOperator.gt.compare(a, b));
+        }
+
+        @DisplayName("gte operator: should return true if first number is greater than or equal to second")
+        @ParameterizedTest
+        @CsvSource({
+            "10, 10, true",
+            "5, 10, false",
+            "10, 5, true"
+        })
+        void test_gte(int a, int b, boolean result) {
+            assertEquals(result, ComparisonOperator.gte.compare(a, b));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for fromName() method")
+    class FromNameTests {
+
+        @DisplayName("should return eq operator for lowercase name")
+        @Test
+        void test_lowerCase() {
+            assertEquals(ComparisonOperator.eq, ComparisonOperator.fromName("eq"));
+        }
+
+        @DisplayName("should return gt operator for uppercase name")
+        @Test
+        void test_upperCase() {
+            assertEquals(ComparisonOperator.gt, ComparisonOperator.fromName("GT"));
+        }
+
+        @DisplayName("should return lte operator for mixed case name")
+        @Test
+        void test_mixedCase() {
+            assertEquals(ComparisonOperator.lte, ComparisonOperator.fromName("LtE"));
+        }
+
+        @DisplayName("should throw IllegalArgumentException for unknown operator name")
+        @Test
+        void test_unknownName() {
+            assertThrows(IllegalArgumentException.class,
+                () -> ComparisonOperator.fromName("xxx"));
+        }
+    }
+
+    @DisplayName("Tests for handling null values with eq and ne operators")
+    @ParameterizedTest(name = "{0}.compare({1}, {2}) should be {3}")
+    @MethodSource("validNullCases")
+    void test_null_handling(ComparisonOperator operator, Integer a, Integer b, Boolean result) {
+        assertEquals(result, operator.compare(a, b));
+    }
+
+    @DisplayName("Tests for handling null values with lt, lte, gt, gte operators (should throw IllegalArgumentException)")
+    @ParameterizedTest(name = "{0}.compare({1}, {2}) should throw IllegalArgumentException")
+    @MethodSource("exceptionNullCases")
+    void test_null_throwIllegalArgumentException(ComparisonOperator operator, Integer a, Integer b) {
+        assertThrows(IllegalArgumentException.class,
+            () -> operator.compare(a, b),
+            String.format("Cannot compare %s with %s using operator %s", a, b, operator)
+        );
+    }
+
+    private static Stream<Arguments> validNullCases() {
+        return Stream.of(
+            // both null
+            Arguments.of(ComparisonOperator.eq, null, null, true),
+            Arguments.of(ComparisonOperator.ne, null, null, false),
+            // left null
+            Arguments.of(ComparisonOperator.eq, null, 5, false),
+            Arguments.of(ComparisonOperator.ne, null, 5, true),
+            // right null
+            Arguments.of(ComparisonOperator.eq, 5, null, false),
+            Arguments.of(ComparisonOperator.ne, 5, null, true)
+        );
+    }
+
+    private static Stream<Arguments> exceptionNullCases() {
+        return Stream.of(
+            // both null
+            Arguments.of(ComparisonOperator.lt, null, null),
+            Arguments.of(ComparisonOperator.lte, null, null),
+            Arguments.of(ComparisonOperator.gt, null, null),
+            Arguments.of(ComparisonOperator.gte, null, null),
+            // left null
+            Arguments.of(ComparisonOperator.lt, null, 5),
+            Arguments.of(ComparisonOperator.lte, null, 5),
+            Arguments.of(ComparisonOperator.gt, null, 5),
+            Arguments.of(ComparisonOperator.gte, null, 5),
+            // right null
+            Arguments.of(ComparisonOperator.lt, 5, null),
+            Arguments.of(ComparisonOperator.lte, 5, null),
+            Arguments.of(ComparisonOperator.gt, 5, null),
+            Arguments.of(ComparisonOperator.gte, 5, null)
+        );
+    }
+}

--- a/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
+++ b/src/test/java/org/wiremock/extensions/state/functionality/StateRequestMatcherTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -894,6 +896,123 @@ class StateRequestMatcherTest extends AbstractTestBase {
 
                     getAndAssertContextMatcher(context, HttpStatus.SC_NOT_FOUND);
                 }
+            }
+        }
+
+        @DisplayName("with numericComparisons matchers")
+        @Nested
+        public class NumericComparisons {
+
+            private final String contextValue = "1000";
+            private String context;
+
+            @BeforeEach
+            void setup() {
+                createPostStub();
+                context = postAndAssertContextValue(contextValue);
+            }
+
+            @DisplayName("NumericComparisons: interval matching")
+            @ParameterizedTest(name = "[{index}] Expect {4} when {2} {3} < value < {0} {1}")
+            @CsvSource({
+                "lte, 1100, gt,  500, 200",
+                "lte, 1000, gt,  500, 200",
+                "lt,  1000, gte, 500, 404",
+                "lte, 1000, gte, 500, 200",
+                "lt,  1000, gt,  500, 404",
+                "lt,  600,  gt,  500, 404",
+                "gte, 1000, lte, 1000, 200",
+                "gt,  1000, lte, 2000, 404",
+                "gte, 999,  lte, 1000, 200",
+                "gte, 1001, lte, 2000, 404"
+            })
+            void test_intervals(String op1, String val1, String op2, String val2, int status) {
+                createGetStub("numericComparisons", Map.of("stateValue", Map.of(
+                    op1, val1,
+                    op2, val2
+                )));
+
+                getAndAssertContextMatcher(context, status);
+            }
+
+            @DisplayName("NumericComparisons: half-intervals matching (only lower or upper bound)")
+            @ParameterizedTest(name = "[{index}] Expect {2} when {0} {1}")
+            @CsvSource({
+                "gte, 900,  200",
+                "gte, 1000, 200",
+                "gte, 1100, 404",
+                "gt,  900,  200",
+                "gt,  1000, 404",
+                "gt,  1100, 404",
+                "lte, 900,  404",
+                "lte, 1000, 200",
+                "lte, 1100, 200",
+                "lt,  900,  404",
+                "lt,  1000, 404",
+                "lt,  1100, 200"
+            })
+            void test_halfIntervals(String operator, String value, int status) {
+                createGetStub("numericComparisons", Map.of("stateValue", Map.of(
+                    operator, value
+                )));
+
+                getAndAssertContextMatcher(context, status);
+            }
+
+
+            @DisplayName("NumericComparisons: not numeric values handling")
+            @ParameterizedTest(name = "[{index}] Expect {2} when operator {0} with value {1}")
+            @CsvSource({
+                "gt,  null, 500",
+                "gte, null, 500",
+                "lt,  null, 500",
+                "lte, null, 500",
+                "eq,  null, 500",
+                "neq, null, 500",
+            })
+            void test_notNumericValues(String operator, Object value, int status) {
+                createGetStub("numericComparisons", Map.of("stateValue", Map.of(
+                    operator, value
+                )));
+
+                getAndAssertContextMatcher(context, status)
+                    .body(containsString(
+                        String.format("StateRequestMatcher: Cannot convert string %1$s to double: For input string: \"%1$s\"", value)
+                    )
+                );
+            }
+
+            @DisplayName("NumericComparisons: unknown operator handling")
+            @Test
+            void test_unknownOperator() {
+                String unknownOperator = "abc";
+                createGetStub("numericComparisons", Map.of("stateValue", Map.of(
+                    unknownOperator, "1000"
+                )));
+
+                getAndAssertContextMatcher(context, 500)
+                    .body(containsString(
+                            String.format("StateRequestMatcher: Cannot compare 1000.0 and 1000.0: Unknown operator name: %s", unknownOperator)
+                        )
+                    );
+            }
+
+            @DisplayName("NumericComparisons: equal/notEqual operators")
+            @ParameterizedTest
+            @CsvSource({
+                "eq, 1000, 200",
+                "eq, 900,  404",
+                "eq, 1100, 404",
+                "ne, 1000, 404",
+                "ne, 900,  200",
+                "ne, 1100, 200",
+            })
+            void test_equalAndNotEqual(String operator, String value, int status) {
+                createGetStub("numericComparisons", Map.of("stateValue", Map.of(
+                    operator, value
+                )));
+
+                getAndAssertContextMatcher(context, status);
             }
         }
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR adds numeric comparisons functionality to the state-matcher, allowing matching requests based on numeric conditions for state properties. The implementation supports comparison operators (gt, gte, lt, lte, eq, ne) with both constant values and state property values via templating.

## References

- Implements feature requested in issue #184 
- Builds upon existing state-matcher infrastructure
- Follows same patterns as other matcher types in the extension

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

## Changes

- Added `ComparisonOperator` enum to handle numeric comparison operations
- Extended `StateRequestMatcher` to support `numericComparisons` parameter
- Added comprehensive unit tests covering all comparison operators and edge cases
- Updated documentation with usage examples and configuration details

## Testing

- Unit tests verify all comparison operators work correctly
- Tests cover both constant values and templated state property values
- Edge cases like non-numeric values and missing properties are tested
- Integration tests demonstrate real-world usage scenarios

## Documentation

Added new "Numeric comparisons match" section to README.md with:
- Supported operators reference
- Basic usage example with constant values
- Advanced example with state property templating
- Multiple property comparisons example
- Important usage notes and limitations

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->