### PR TITLE
Fix the paths of the example URLs for the Admin API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1257,12 +1257,12 @@ and setting `verbose=true` or starting WireMock standalone (or docker) with `ver
 
 The extension provides an admin API endpoint to retrieve the current state of the context store as well as to delete contexts:
 
-| Endpoint                                      | Method | Description                                                                             | Example                                                |
-|-----------------------------------------------|--------|-----------------------------------------------------------------------------------------|--------------------------------------------------------|
-| `/__admin/state-extension/contexts`           | GET    | Retrieves all context names (or an empty list if there are none). Always returns `200`. | `GET http://localhost:8080/__admin/state`              |
-| `/__admin/state-extension/contexts/{context}` | GET    | Retrieve internal structure of a context. Returns `404` if the context does not exist.  | `GET http://localhost:8080/__admin/state/myContext`    |
-| `/__admin/state-extension/contexts`           | DELETE | Deletes all contexts. Always returns `204`.                                             | `DELETE http://localhost:8080/__admin/state`           |
-| `/__admin/state-extension/contexts/{context}` | DELETE | Deletes a single context. Always returns `204`.                                         | `DELETE http://localhost:8080/__admin/state/myContext` |
+| Endpoint                                      | Method | Description                                                                             | Example                                                                   |
+|-----------------------------------------------|--------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| `/__admin/state-extension/contexts`           | GET    | Retrieves all context names (or an empty list if there are none). Always returns `200`. | `GET http://localhost:8080/__admin/state-extension/contexts`              |
+| `/__admin/state-extension/contexts/{context}` | GET    | Retrieve internal structure of a context. Returns `404` if the context does not exist.  | `GET http://localhost:8080/__admin/state-extension/contexts/myContext`    |
+| `/__admin/state-extension/contexts`           | DELETE | Deletes all contexts. Always returns `204`.                                             | `DELETE http://localhost:8080/__admin/state-extension/contexts`           |
+| `/__admin/state-extension/contexts/{context}` | DELETE | Deletes a single context. Always returns `204`.                                         | `DELETE http://localhost:8080/__admin/state-extension/contexts/myContext` |
 
 **Note:** The admin API intentionally does not provide `PUT` or `POST` methods for security and stability reasons.
 


### PR DESCRIPTION
Fix the example parts of the table describing the admin APIs, they are currently incorrect.
The examples currently does not match the value in the Endpoint column in the table, so
just doing a copy/paste of the example does not work currently.

## References

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ x] The PR request is well described and justified, including the body and the references
- [ x] The PR title represents the desired changelog entry
- [ x] The repository's code style is followed (see the contributing guide)
- [ x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

