### PR TITLE
allow overwriting expiration for standalone jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ storing any data.
 The standalone jar can be downloaded from [GitHub](https://github.com/wiremock/wiremock-extension-state/packages/1902576) .
 
 ```bash
-java -cp "wiremock-state-extension-standalone-0.4.0.jar:wiremock-standalone-3.3.0.jar" wiremock.Run
+java -cp "wiremock-state-extension-standalone-0.6.0.jar:wiremock-standalone-3.13.2.jar" wiremock.Run
 ```
 
 ### Docker
@@ -707,6 +707,10 @@ The default expiration is 60 minutes. The default value can be overwritten (`0` 
 int expiration = 1024;
 var store = new CaffeineStore(expiration);
 ```
+
+**EXPERIMENTAL/ALPHA**: For the standalone jar, the expiration can also be overwritten by setting the environment variable
+`WIREMOCK_STATE_EXTENSION_CONTEXT_EXPIRATION_SEC` (expiration in seconds).
+This variable or the mechanism is subject to change without further notice as soon as there is a generic way to configure extensions in WireMock.
 
 ## Match a request against a context
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
     id 'jacoco'
-    id 'com.diffplug.spotless' version '8.4.0'
+    id 'com.diffplug.spotless' version '7.2.1'
     id 'org.wiremock.tools.gradle.wiremock-extension-convention' version '0.5.1'
 }
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -98,11 +98,11 @@ cd ..
 
 ### Step 3: download wiremock standalone
 
-From directory of this README:
+From the directory of this README:
 
 ```shell
 cd ..
-curl -o build/libs/wiremock-standalone-3.6.0.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.6.0/wiremock-standalone-3.6.0.jar
+curl -o build/libs/wiremock-standalone-3.13.2.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.13.2/wiremock-standalone-3.13.2.jar
 ```
 
 ### Step 4: Start WireMock with the State Extension
@@ -111,7 +111,7 @@ From directory of this README:
 
 ```shell
 cd ..
-java -cp build/libs/wiremock-state-extension-standalone-0.6.0-SNAPSHOT.jar:build/libs/wiremock-standalone-3.6.0.jar wiremock.Run --verbose --global-response-templating --root-dir demo/stubs
+java -cp build/libs/wiremock-state-extension-standalone-0.6.0-SNAPSHOT.jar:build/libs/wiremock-standalone-3.13.1.jar wiremock.Run --verbose --global-response-templating --root-dir demo/stubs
 ```
 
 This command starts WireMock with the State Extension enabled.

--- a/src/main/java/org/wiremock/extensions/state/CaffeineStore.java
+++ b/src/main/java/org/wiremock/extensions/state/CaffeineStore.java
@@ -23,6 +23,9 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
+import static org.wiremock.extensions.state.internal.ExtensionLogger.logger;
+
 public class CaffeineStore implements Store<String, Object> {
 
     private static final int DEFAULT_EXPIRATION_SECONDS = 60 * 60;
@@ -35,6 +38,7 @@ public class CaffeineStore implements Store<String, Object> {
 
     public CaffeineStore(int expirationSeconds) {
         var builder = Caffeine.newBuilder();
+        notifier().info(String.format("Using CaffeineStore with expirationSeconds=%d", expirationSeconds));
         if (expirationSeconds == 0) {
             builder.expireAfterWrite(Duration.ofSeconds(DEFAULT_EXPIRATION_SECONDS));
         } else {

--- a/src/main/java/org/wiremock/extensions/state/StandaloneStateExtension.java
+++ b/src/main/java/org/wiremock/extensions/state/StandaloneStateExtension.java
@@ -25,6 +25,15 @@ package org.wiremock.extensions.state;
 public class StandaloneStateExtension extends StateExtension {
 
     public StandaloneStateExtension() {
-        super(new CaffeineStore());
+        super(new CaffeineStore(getExpiration()));
+    }
+
+    private static int getExpiration() {
+        var expiration = System.getenv("WIREMOCK_STATE_EXTENSION_CONTEXT_EXPIRATION_SEC");
+        try {
+            return Integer.parseInt(expiration);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
mitigation to set the context expiration via environment variable as long as there's no official way to configure extensions.

## References

- #101

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
